### PR TITLE
readd Swedish

### DIFF
--- a/nemo_text_processing/inverse_text_normalization/inverse_normalize.py
+++ b/nemo_text_processing/inverse_text_normalization/inverse_normalize.py
@@ -155,7 +155,7 @@ def parse_args():
     parser.add_argument(
         "--language",
         help="language",
-        choices=['en', 'de', 'es', 'pt', 'ru', 'fr', 'vi', 'ar', 'es_en', 'zh'],
+        choices=['en', 'de', 'es', 'pt', 'ru', 'fr', 'sv', 'vi', 'ar', 'es_en', 'zh'],
         default="en",
         type=str,
     )


### PR DESCRIPTION
'sv' was removed from the list of choices when zh itn was added.

