### PR TITLE
Unpin setuptools

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,7 +6,7 @@ pandas
 pynini==2.1.5
 regex
 sacremoses>=0.0.43
-setuptools==65.5.1
+setuptools>=65.5.1
 tqdm>=4.41.0
 transformers
 wget


### PR DESCRIPTION
This PR seeks to support alternate versions of `setuptools` for those (like me) who cannot use the pinned version.

See: https://github.com/NVIDIA/NeMo/issues/7475