### PR TITLE
relax `pynini` constraint to support `poetry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install nemo_text_processing
 
 **_NOTE:_** This should work on any Linux OS with x86_64. Pip installation on MacOS and Windows are not supported due to the dependency [Pynini](https://www.openfst.org/twiki/bin/view/GRM/Pynini). On a platform other than Linux x86_64, installing from Pip tries to compile Pynini from scratch, and requires OpenFst headers and libraries to be in the expected place. So if it's working for you, it's because you happen to have installed OpenFst in the right way in the right place. So if you want to Pip install Pynini on MacOS, you have to have pre-compiled and pre-installed OpenFst. The Pynini README for that version should tell you which version it needs and what `--enable-foo` flags to use.
 Instead, we recommend you to use conda-forge to install Pynini on MacOS or Windows:
-`conda install -c conda-forge pynini=2.1.5`.
+`conda install -c conda-forge pynini=2.1.6`.
 
 
 ###  Pip from source

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ editdistance
 inflect
 joblib
 pandas
-pynini==2.1.5
+pynini~=2.1.5
 regex
 sacremoses>=0.0.43
 setuptools>=65.5.1

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -2,7 +2,7 @@ black==19.10b0
 click==8.0.2
 isort[requirements]>5.1.0,<6.0.0
 parameterized
-pynini==2.1.5
+pynini~=2.1.5
 pytest
 pytest-runner
 ruamel.yaml


### PR DESCRIPTION
# What does this PR do ?

Makes sure NeMo-text-processing can be installed with `poetry`. This is done by relaxing the constraint on `pynini`, which was the only blocker for supporting `poetry add nemo-text-processing`.

Addresses 

- https://github.com/NVIDIA/NeMo-text-processing/issues/145

To reproduce install failure, the following script helps:
```bash
#!/bin/bash

set -ex

# Demo the failure of installing pynini==2.1.5 and that this also blocks installing nemo text processing

# Install poetry if not already installed
if ! command -v poetry &> /dev/null
then
    echo "poetry not found, installing poetry"
    curl -sSL https://install.python-poetry.org | python3 - -y
fi

# Add poetry to path
PATH="$PATH:$HOME/.local/bin"

# Make project and install pynini==2.1.5
# Set clean up on exit using trap
trap "rm -rf /tmp/pynini-test" EXIT

cd /tmp
rm -rf pynini-test
mkdir pynini-test
cd pynini-test
poetry init -n

set +e
# Install pynini==2.1.5 will show an error
poetry add pynini==2.1.5

# Install nemo text processing will show an error
poetry add nemo_text_processing==0.2.2rc0

set -e

# Show that pynini==2.1.6 installs successfully
poetry add pynini==2.1.6

# Remove and install from git
poetry remove pynini

# Install branch that corresponds to PR
poetry add git+https://github.com/jvdw-synth/NeMo-text-processing.git#jvdw-synth/relax-pynini-constraint

poetry show -v | grep pynini
poetry show -v | grep nemo
```


**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Test
