### PR TITLE
Sh postprocess

### DIFF
--- a/tests/nemo_text_processing/en/test_sparrowhawk_normalization.sh
+++ b/tests/nemo_text_processing/en/test_sparrowhawk_normalization.sh
@@ -11,7 +11,10 @@ runtest () {
   while read testcase; do
     IFS='~' read written spoken <<< $testcase
     # replace non breaking space with breaking space
-    denorm_pred=$(echo $written | normalizer_main --config=sparrowhawk_configuration_pp.ascii_proto 2>&1 | tail -n 1 | sed 's/\xC2\xA0/ /g')
+    # Use below if postprocessor is not used. Comment if it is used
+    denorm_pred=$(echo $written | normalizer_main --config=sparrowhawk_configuration.ascii_proto 2>&1 | tail -n 1 | sed 's/\xC2\xA0/ /g')
+    # Use below if postprocessor is  used. Comment if it is not used
+    #denorm_pred=$(echo $written | normalizer_main --config=sparrowhawk_configuration_pp.ascii_proto 2>&1 | tail -n 1 | sed 's/\xC2\xA0/ /g')
 
     # trim white space
     spoken="$(echo -e "${spoken}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"

--- a/tests/nemo_text_processing/en/test_sparrowhawk_normalization.sh
+++ b/tests/nemo_text_processing/en/test_sparrowhawk_normalization.sh
@@ -11,7 +11,7 @@ runtest () {
   while read testcase; do
     IFS='~' read written spoken <<< $testcase
     # replace non breaking space with breaking space
-    denorm_pred=$(echo $written | normalizer_main --config=sparrowhawk_configuration.ascii_proto 2>&1 | tail -n 1 | sed 's/\xC2\xA0/ /g')
+    denorm_pred=$(echo $written | normalizer_main --config=sparrowhawk_configuration_pp.ascii_proto 2>&1 | tail -n 1 | sed 's/\xC2\xA0/ /g')
 
     # trim white space
     spoken="$(echo -e "${spoken}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"

--- a/tools/text_processing_deployment/Dockerfile
+++ b/tools/text_processing_deployment/Dockerfile
@@ -32,7 +32,6 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v2.5.0/pr
 RUN tar xzvf protobuf-2.5.0.tar.gz
 RUN cd protobuf-2.5.0 && ./configure && make && make install && ldconfig
 RUN conda install -c conda-forge thrax=1.3.4 -y
-RUN echo "Rerun from here"
 RUN git clone https://github.com/anand-nv/sparrowhawk.git && cd sparrowhawk &&  git checkout nemo_tests &&   apt-get install -y autoconf &&     bash autoreconf && ./configure && make && make install && ldconfig
 RUN git clone https://github.com/kward/shunit2.git
 RUN echo "DONE"

--- a/tools/text_processing_deployment/Dockerfile
+++ b/tools/text_processing_deployment/Dockerfile
@@ -32,7 +32,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v2.5.0/pr
 RUN tar xzvf protobuf-2.5.0.tar.gz
 RUN cd protobuf-2.5.0 && ./configure && make && make install && ldconfig
 RUN conda install -c conda-forge thrax=1.3.4 -y
-RUN git clone https://github.com/yzhang123/sparrowhawk.git
-RUN cd sparrowhawk &&  git checkout test &&   apt-get install -y autoconf &&     bash autoreconf && ./configure && make && make install && ldconfig
+RUN echo "Rerun from here"
+RUN git clone https://github.com/anand-nv/sparrowhawk.git && cd sparrowhawk &&  git checkout nemo_tests &&   apt-get install -y autoconf &&     bash autoreconf && ./configure && make && make install && ldconfig
 RUN git clone https://github.com/kward/shunit2.git
 RUN echo "DONE"

--- a/tools/text_processing_deployment/docker/launch.sh
+++ b/tools/text_processing_deployment/docker/launch.sh
@@ -50,7 +50,7 @@ elif [[ $MODE == "test_itn_grammars" ]]; then
 fi
 
 echo $MOUNTS
-docker run -it --rm \
+docker run -it -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 --rm \
   --shm-size=4g \
   --ulimit memlock=-1 \
   --ulimit stack=67108864 \

--- a/tools/text_processing_deployment/pynini_export.py
+++ b/tools/text_processing_deployment/pynini_export.py
@@ -128,8 +128,10 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.en.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
+        from nemo_text_processing.text_normalization.en.verbalizers.post_processing import (
+            PostProcessingFst as TNPostProcessingFst,
+        )
         from nemo_text_processing.text_normalization.en.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-        from nemo_text_processing.text_normalization.en.verbalizers.post_processing import PostProcessingFst as TNPostProcessingFst
 
     elif args.language == 'de':
         from nemo_text_processing.inverse_text_normalization.de.taggers.tokenize_and_classify import (

--- a/tools/text_processing_deployment/pynini_export.py
+++ b/tools/text_processing_deployment/pynini_export.py
@@ -52,6 +52,8 @@ def tn_grammars(**kwargs):
         ).fst
     }
     d['verbalize'] = {'ALL': TNVerbalizeFst(deterministic=True).fst, 'REDUP': pynini.accep("REDUP")}
+    if TNPostProcessingFst is not None:
+        d['post_process'] = {'POSTPROCESSOR': TNPostProcessingFst().fst}
     return d
 
 
@@ -66,6 +68,8 @@ def export_grammars(output_dir, grammars):
 
     for category, graphs in grammars.items():
         out_dir = os.path.join(output_dir, category)
+        if category == "post_process":
+            out_dir = os.path.join(output_dir, "verbalize")
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
             time.sleep(1)
@@ -113,7 +117,7 @@ if __name__ == '__main__':
 
     if args.language in ['pt', 'ru', 'vi', 'es_en'] and args.grammars == 'tn_grammars':
         raise ValueError('Only ITN grammars could be deployed in Sparrowhawk for the selected languages.')
-
+    TNPostProcessingFst = None
     if args.language == 'en':
         from nemo_text_processing.inverse_text_normalization.en.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -125,6 +129,8 @@ if __name__ == '__main__':
             ClassifyFst as TNClassifyFst,
         )
         from nemo_text_processing.text_normalization.en.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
+        from nemo_text_processing.text_normalization.en.verbalizers.post_processing import PostProcessingFst as TNPostProcessingFst
+
     elif args.language == 'de':
         from nemo_text_processing.inverse_text_normalization.de.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,


### PR DESCRIPTION
# What does this PR do ?
Add support for postprocessor and preprocessor far in sparrowhawk tests

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [ ] Do all unittests finish successfully before sending PR?
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
~~This currently fails since `postprocess.far` has been enabled in sparrowhawk and the test cases do not consider the use of a postprocessor~~
Switch to using a postprocessor when tests are updated. For now reverts to not using postprocessor in tests


**PR Type**:
- [x] Test
