### PR TITLE
Fix text=line['text'] to text=line[text_field]

### DIFF
--- a/nemo_text_processing/text_normalization/normalize_with_audio.py
+++ b/nemo_text_processing/text_normalization/normalize_with_audio.py
@@ -291,7 +291,7 @@ class NormalizerWithAudio(Normalizer):
         line = json.loads(line)
 
         normalized_text = self.normalize(
-            text=line["text"],
+            text=line[text_field],
             verbose=verbose,
             n_tagged=n_tagged,
             punct_post_process=punct_post_process,


### PR DESCRIPTION
Related with issue #152

`text=line['text']` to `text=line[text_field]`