### PR TITLE
Use raw docstring in split_text_into_sentences

### DIFF
--- a/nemo_text_processing/text_normalization/normalize.py
+++ b/nemo_text_processing/text_normalization/normalize.py
@@ -517,7 +517,7 @@ class Normalizer:
         logger.warning(f'Normalized version saved at {output_filename}')
 
     def split_text_into_sentences(self, text: str, additional_split_symbols: str = "") -> List[str]:
-        """
+        r"""
         Split text into sentences.
 
         Args:


### PR DESCRIPTION
# What does this PR do ?

This changes the docstring in the `split_text_into_sentences` method in `Normalizer()` to a raw string. Without this, there is an invalid escape sequence ('\s') on line 526 in the docstring that can cause a syntax error.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [x] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``  


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [ ] Test
