### PR TITLE
remove unused function from ar tn decimals

### DIFF
--- a/nemo_text_processing/text_normalization/ar/taggers/decimal.py
+++ b/nemo_text_processing/text_normalization/ar/taggers/decimal.py
@@ -19,31 +19,6 @@ from nemo_text_processing.text_normalization.ar.graph_utils import NEMO_DIGIT, N
 from nemo_text_processing.text_normalization.ar.utils import get_abs_path
 
 
-def get_quantity(decimal: "pynini.FstLike", cardinal_up_to_hundred: "pynini.FstLike") -> "pynini.FstLike":
-    """
-    Returns FST that transforms either a cardinal or decimal followed by a quantity into a numeral,
-    e.g.  5 مليون -> integer_part: "خمسة" quantity: "مليون"
-    e.g. 5.4 مليون -> integer_part: "خمسة" fractional_part: "اربعة من عشرة" quantity: "مليون"
-
-    Args: 
-        decimal: decimal FST
-        cardinal_up_to_hundred: cardinal FST
-    """
-    numbers = cardinal_up_to_hundred
-
-    res = (
-        pynutil.insert('integer_part: "')
-        + numbers
-        + pynutil.insert('"')
-        + pynini.accep(" ")
-        + pynutil.insert('quantity: "')
-        + quantities
-        + pynutil.insert('"')
-    )
-    res |= decimal + pynini.accep(" ") + pynutil.insert('quantity: "') + quantities + pynutil.insert('"')
-    return res
-
-
 class DecimalFst(GraphFst):
     """
     Finite state transducer for classifying decimal, e.g. 


### PR DESCRIPTION
# What does this PR do ?

Address issue #162 -- function with bug is not used in the code so we can just remove it

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Have you signed your commits? Use ``git commit -s`` to sign.
- [ ] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [ ] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [ ] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [ ] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [ ] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [ ] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [ ] Remove import guards (`try import: ... except: ...`) if not already done.
- [ ] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [ ] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
