### PR TITLE
preparing release, updating change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [r1.0.0] - 2024-05-03
+
+### Added
+
+- Sentence level ZH (Mandarin Chinese) TN (#112)
+- Enabled post-processing support for Sparrowhawk TN test (#147) 
+
+### Fixed
+
+- `normalize_with_audio` text-field variable changed (#153)
+- `run_evaluate` script for ITN updated for additional languages and casing (#164)
+
+### Changed
+
+- Docstring update (#157)
+
+
+### Removed
+
+- Removed unused function from AR (Arabic) TN decimals (#165)
+
+

--- a/nemo_text_processing/package_info.py
+++ b/nemo_text_processing/package_info.py
@@ -16,7 +16,7 @@
 MAJOR = 1
 MINOR = 0
 PATCH = 0
-PRE_RELEASE = 'r0'
+PRE_RELEASE = 'r'
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/nemo_text_processing/package_info.py
+++ b/nemo_text_processing/package_info.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-MAJOR = 0
-MINOR = 3
+MAJOR = 1
+MINOR = 0
 PATCH = 0
-PRE_RELEASE = 'rc0'
+PRE_RELEASE = 'r0'
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
# What does this PR do ?

r1.0.0 Release


# Before your PR is "Ready for review"
**Pre checks**:
- [y ] Have you signed your commits? Use ``git commit -s`` to sign.
- [ y] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [n ] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [ y] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [y ] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [ y] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [n ] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [ n] Remove import guards (`try import: ... except: ...`) if not already done.
- [n ] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [y] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [y] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
