### PR TITLE
FR_TN_Fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     EN_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/11-18-23-0'
     ES_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/10-27-23-0'
     ES_EN_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-13-23-2'
-    FR_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/12-05-23-0'
+    FR_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-03-24-0'
     HU_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-08-23-0'
     PT_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-08-23-0'
     RU_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-08-23-0'

--- a/nemo_text_processing/text_normalization/de/data/electronic/domain.tsv
+++ b/nemo_text_processing/text_normalization/de/data/electronic/domain.tsv
@@ -1,7 +1,7 @@
 .com	punkt com
 .uk	punkt uk
 .fr	punkt fr
-.net	dot net
+.net	punkt net
 .br	punkt br
 .in	punkt in
 .ru	punkt ru

--- a/nemo_text_processing/text_normalization/de/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/de/taggers/electronic.py
@@ -124,7 +124,6 @@ from nemo_text_processing.text_normalization.de.utils import get_abs_path, load_
 from nemo_text_processing.text_normalization.en.graph_utils import (
     NEMO_ALPHA,
     NEMO_DIGIT,
-    NEMO_SIGMA,
     GraphFst,
     insert_space,
 )

--- a/nemo_text_processing/text_normalization/de/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/de/taggers/electronic.py
@@ -1,4 +1,3 @@
-'''
 # Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,9 +53,15 @@ class ElectronicFst(GraphFst):
         accepted_symbols = [
             x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))
         ]
-        accepted_symbols = pynini.union(*accepted_symbols) - dot
-        accepted_characters = pynini.closure(NEMO_ALPHA | NEMO_DIGIT | accepted_symbols)
-        all_characters = pynini.closure(NEMO_ALPHA | NEMO_DIGIT | all_symbols)
+        accepted_symbols = (
+            pynini.union(*accepted_symbols) - dot
+        )  # alphabet of accepted symbols excluding the '.'
+        accepted_characters = pynini.closure(
+            NEMO_ALPHA | NEMO_DIGIT | accepted_symbols
+        )  # alphabet of accepted chars excluding the '.'
+        all_characters = pynini.closure(
+            NEMO_ALPHA | NEMO_DIGIT | all_symbols
+        )  # alphabet of all accepted chars
 
         # email
         username = (
@@ -70,13 +75,9 @@ class ElectronicFst(GraphFst):
         domain_common_graph = (
             pynutil.insert('domain: "')
             + accepted_characters
-            + accepted_common_domains
-            + pynini.closure(
-                (accepted_symbols | dot) + pynini.closure(accepted_characters, 1), 0, 1
-            )
+            + (accepted_common_domains | (dot + accepted_characters))
             + pynutil.insert('"')
         )
-        graph = (username + domain_graph) | domain_common_graph
 
         # social media tags
         tag = (
@@ -99,80 +100,4 @@ class ElectronicFst(GraphFst):
         final_graph = self.add_tokens(
             self.graph + pynutil.insert(" preserve_order: true")
         )
-        self.fst = final_graph.optimize()
-'''
-
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
-import pynini
-from pynini.lib import pynutil
-
-from nemo_text_processing.text_normalization.de.utils import get_abs_path, load_labels
-from nemo_text_processing.text_normalization.en.graph_utils import NEMO_ALPHA, NEMO_DIGIT, GraphFst, insert_space
-
-
-class ElectronicFst(GraphFst):
-    """
-    Finite state transducer for classifying electronic: email addresses
-        e.g. "abc@hotmail.com" -> electronic { username: "abc" domain: "hotmail.com" preserve_order: true }
-        e.g. "www.abc.com/123" -> electronic { protocol: "www." domain: "abc.com/123" preserve_order: true }
-
-    Args:
-        deterministic: if True will provide a single transduction option,
-            for False multiple transduction are generated (used for audio-based normalization)
-    """
-
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="electronic", kind="classify", deterministic=deterministic)
-
-        dot = pynini.accep(".")
-        accepted_common_domains = [x[0] for x in load_labels(get_abs_path("data/electronic/domain.tsv"))]
-        accepted_common_domains = pynini.union(*accepted_common_domains)
-        all_symbols = [x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))]
-        all_symbols = pynini.union(*all_symbols)
-        accepted_symbols = [x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))]
-        accepted_symbols = pynini.union(*accepted_symbols) - dot  # alphabet of accepted symbols excluding the '.'
-        accepted_characters = pynini.closure(
-            NEMO_ALPHA | NEMO_DIGIT | accepted_symbols
-        )  # alphabet of accepted chars excluding the '.'
-        all_characters = pynini.closure(NEMO_ALPHA | NEMO_DIGIT | all_symbols)  # alphabet of all accepted chars
-
-        # email
-        username = pynutil.insert('username: "') + accepted_characters + pynutil.insert('"') + pynini.cross("@", " ")
-        domain_graph = accepted_characters + dot + accepted_characters
-        domain_graph = pynutil.insert('domain: "') + domain_graph + pynutil.insert('"')
-        domain_common_graph = (
-            pynutil.insert('domain: "')
-            + accepted_characters
-            + (accepted_common_domains | (dot + accepted_characters))
-            + pynutil.insert('"')
-        )
-
-        # social media tags
-        tag = pynini.cross("@", "") + pynutil.insert('username: "') + all_characters + pynutil.insert('"')
-
-        graph = tag | (username + domain_graph) | domain_common_graph
-
-        # url
-        protocol_start = pynini.accep("https://") | pynini.accep("http://")
-        protocol_end = pynini.accep("www.")
-        protocol = protocol_start | protocol_end | (protocol_start + protocol_end)
-        protocol = pynutil.insert('protocol: "') + protocol + pynutil.insert('"')
-        graph |= protocol + insert_space + (domain_graph | domain_common_graph)
-        self.graph = graph
-
-        final_graph = self.add_tokens(self.graph + pynutil.insert(" preserve_order: true"))
         self.fst = final_graph.optimize()

--- a/nemo_text_processing/text_normalization/de/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/de/taggers/electronic.py
@@ -17,7 +17,12 @@ import pynini
 from pynini.lib import pynutil
 
 from nemo_text_processing.text_normalization.de.utils import get_abs_path, load_labels
-from nemo_text_processing.text_normalization.en.graph_utils import NEMO_ALPHA, NEMO_DIGIT, GraphFst, insert_space
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    NEMO_ALPHA,
+    NEMO_DIGIT,
+    GraphFst,
+    insert_space,
+)
 
 
 class ElectronicFst(GraphFst):
@@ -32,35 +37,65 @@ class ElectronicFst(GraphFst):
     """
 
     def __init__(self, deterministic: bool = True):
-        super().__init__(name="electronic", kind="classify", deterministic=deterministic)
+        super().__init__(
+            name="electronic", kind="classify", deterministic=deterministic
+        )
 
         dot = pynini.accep(".")
-        accepted_common_domains = [x[0] for x in load_labels(get_abs_path("data/electronic/domain.tsv"))]
+        accepted_common_domains = [
+            x[0] for x in load_labels(get_abs_path("data/electronic/domain.tsv"))
+        ]
         accepted_common_domains = pynini.union(*accepted_common_domains)
-        accepted_symbols = [x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))]
+        all_symbols = [
+            x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))
+        ]
+        all_symbols = pynini.union(*all_symbols)
+        accepted_symbols = [
+            x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))
+        ]
         accepted_symbols = pynini.union(*accepted_symbols) - dot
         accepted_characters = pynini.closure(NEMO_ALPHA | NEMO_DIGIT | accepted_symbols)
+        all_characters = pynini.closure(NEMO_ALPHA | NEMO_DIGIT | all_symbols)
 
         # email
-        username = pynutil.insert("username: \"") + accepted_characters + pynutil.insert("\"") + pynini.cross('@', ' ')
+        username = (
+            pynutil.insert('username: "')
+            + accepted_characters
+            + pynutil.insert('"')
+            + pynini.cross("@", " ")
+        )
         domain_graph = accepted_characters + dot + accepted_characters
-        domain_graph = pynutil.insert("domain: \"") + domain_graph + pynutil.insert("\"")
+        domain_graph = pynutil.insert('domain: "') + domain_graph + pynutil.insert('"')
         domain_common_graph = (
-            pynutil.insert("domain: \"")
+            pynutil.insert('domain: "')
             + accepted_characters
             + accepted_common_domains
-            + pynini.closure((accepted_symbols | dot) + pynini.closure(accepted_characters, 1), 0, 1)
-            + pynutil.insert("\"")
+            + pynini.closure(
+                (accepted_symbols | dot) + pynini.closure(accepted_characters, 1), 0, 1
+            )
+            + pynutil.insert('"')
         )
         graph = (username + domain_graph) | domain_common_graph
+
+        # social media tags
+        tag = (
+            pynini.cross("@", "")
+            + pynutil.insert('username: "')
+            + all_characters
+            + pynutil.insert('"')
+        )
+
+        graph = tag | (username + domain_graph) | domain_common_graph
 
         # url
         protocol_start = pynini.accep("https://") | pynini.accep("http://")
         protocol_end = pynini.accep("www.")
         protocol = protocol_start | protocol_end | (protocol_start + protocol_end)
-        protocol = pynutil.insert("protocol: \"") + protocol + pynutil.insert("\"")
+        protocol = pynutil.insert('protocol: "') + protocol + pynutil.insert('"')
         graph |= protocol + insert_space + (domain_graph | domain_common_graph)
         self.graph = graph
 
-        final_graph = self.add_tokens(self.graph + pynutil.insert(" preserve_order: true"))
+        final_graph = self.add_tokens(
+            self.graph + pynutil.insert(" preserve_order: true")
+        )
         self.fst = final_graph.optimize()

--- a/nemo_text_processing/text_normalization/de/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/de/taggers/electronic.py
@@ -121,12 +121,7 @@ import pynini
 from pynini.lib import pynutil
 
 from nemo_text_processing.text_normalization.de.utils import get_abs_path, load_labels
-from nemo_text_processing.text_normalization.en.graph_utils import (
-    NEMO_ALPHA,
-    NEMO_DIGIT,
-    GraphFst,
-    insert_space,
-)
+from nemo_text_processing.text_normalization.en.graph_utils import NEMO_ALPHA, NEMO_DIGIT, GraphFst, insert_space
 
 
 class ElectronicFst(GraphFst):

--- a/nemo_text_processing/text_normalization/de/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/de/taggers/electronic.py
@@ -1,3 +1,4 @@
+'''
 # Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,6 +77,112 @@ class ElectronicFst(GraphFst):
             + pynutil.insert('"')
         )
         graph = (username + domain_graph) | domain_common_graph
+
+        # social media tags
+        tag = (
+            pynini.cross("@", "")
+            + pynutil.insert('username: "')
+            + all_characters
+            + pynutil.insert('"')
+        )
+
+        graph = tag | (username + domain_graph) | domain_common_graph
+
+        # url
+        protocol_start = pynini.accep("https://") | pynini.accep("http://")
+        protocol_end = pynini.accep("www.")
+        protocol = protocol_start | protocol_end | (protocol_start + protocol_end)
+        protocol = pynutil.insert('protocol: "') + protocol + pynutil.insert('"')
+        graph |= protocol + insert_space + (domain_graph | domain_common_graph)
+        self.graph = graph
+
+        final_graph = self.add_tokens(
+            self.graph + pynutil.insert(" preserve_order: true")
+        )
+        self.fst = final_graph.optimize()
+'''
+
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pynini
+from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.de.utils import get_abs_path, load_labels
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    NEMO_ALPHA,
+    NEMO_DIGIT,
+    NEMO_SIGMA,
+    GraphFst,
+    insert_space,
+)
+
+
+class ElectronicFst(GraphFst):
+    """
+    Finite state transducer for classifying electronic: email addresses
+        e.g. "abc@hotmail.com" -> electronic { username: "abc" domain: "hotmail.com" preserve_order: true }
+        e.g. "www.abc.com/123" -> electronic { protocol: "www." domain: "abc.com/123" preserve_order: true }
+
+    Args:
+        deterministic: if True will provide a single transduction option,
+            for False multiple transduction are generated (used for audio-based normalization)
+    """
+
+    def __init__(self, deterministic: bool = True):
+        super().__init__(
+            name="electronic", kind="classify", deterministic=deterministic
+        )
+
+        dot = pynini.accep(".")
+        accepted_common_domains = [
+            x[0] for x in load_labels(get_abs_path("data/electronic/domain.tsv"))
+        ]
+        accepted_common_domains = pynini.union(*accepted_common_domains)
+        all_symbols = [
+            x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))
+        ]
+        all_symbols = pynini.union(*all_symbols)
+        accepted_symbols = [
+            x[0] for x in load_labels(get_abs_path("data/electronic/symbols.tsv"))
+        ]
+        accepted_symbols = (
+            pynini.union(*accepted_symbols) - dot
+        )  # alphabet of accepted symbols excluding the '.'
+        accepted_characters = pynini.closure(
+            NEMO_ALPHA | NEMO_DIGIT | accepted_symbols
+        )  # alphabet of accepted chars excluding the '.'
+        all_characters = pynini.closure(
+            NEMO_ALPHA | NEMO_DIGIT | all_symbols
+        )  # alphabet of all accepted chars
+
+        # email
+        username = (
+            pynutil.insert('username: "')
+            + accepted_characters
+            + pynutil.insert('"')
+            + pynini.cross("@", " ")
+        )
+        domain_graph = accepted_characters + dot + accepted_characters
+        domain_graph = pynutil.insert('domain: "') + domain_graph + pynutil.insert('"')
+        domain_common_graph = (
+            pynutil.insert('domain: "')
+            + accepted_characters
+            + (accepted_common_domains | (dot + accepted_characters))
+            + pynutil.insert('"')
+        )
 
         # social media tags
         tag = (

--- a/nemo_text_processing/text_normalization/de/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/de/taggers/tokenize_and_classify.py
@@ -37,7 +37,9 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_space,
     generator_main,
 )
-from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
+from nemo_text_processing.text_normalization.en.taggers.punctuation import (
+    PunctuationFst,
+)
 from nemo_text_processing.utils.logging import logger
 
 
@@ -64,13 +66,16 @@ class ClassifyFst(GraphFst):
         overwrite_cache: bool = False,
         whitelist: str = None,
     ):
-        super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
+        super().__init__(
+            name="tokenize_and_classify", kind="classify", deterministic=deterministic
+        )
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
             far_file = os.path.join(
-                cache_dir, f"_{input_case}_de_tn_{deterministic}_deterministic{whitelist_file}.far"
+                cache_dir,
+                f"_{input_case}_de_tn_{deterministic}_deterministic{whitelist_file}.far",
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -83,16 +88,25 @@ class ClassifyFst(GraphFst):
             self.cardinal = CardinalFst(deterministic=deterministic)
             cardinal_graph = self.cardinal.fst
 
-            self.ordinal = OrdinalFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.ordinal = OrdinalFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             ordinal_graph = self.ordinal.fst
 
-            self.decimal = DecimalFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.decimal = DecimalFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             decimal_graph = self.decimal.fst
 
-            self.fraction = FractionFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.fraction = FractionFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             fraction_graph = self.fraction.fst
             self.measure = MeasureFst(
-                cardinal=self.cardinal, decimal=self.decimal, fraction=self.fraction, deterministic=deterministic
+                cardinal=self.cardinal,
+                decimal=self.decimal,
+                fraction=self.fraction,
+                deterministic=deterministic,
             )
             measure_graph = self.measure.fst
             self.date = DateFst(cardinal=self.cardinal, deterministic=deterministic)
@@ -100,13 +114,21 @@ class ClassifyFst(GraphFst):
             word_graph = WordFst(deterministic=deterministic).fst
             self.time = TimeFst(deterministic=deterministic)
             time_graph = self.time.fst
-            self.telephone = TelephoneFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.telephone = TelephoneFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             telephone_graph = self.telephone.fst
             self.electronic = ElectronicFst(deterministic=deterministic)
             electronic_graph = self.electronic.fst
-            self.money = MoneyFst(cardinal=self.cardinal, decimal=self.decimal, deterministic=deterministic)
+            self.money = MoneyFst(
+                cardinal=self.cardinal,
+                decimal=self.decimal,
+                deterministic=deterministic,
+            )
             money_graph = self.money.fst
-            self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
+            self.whitelist = WhiteListFst(
+                input_case=input_case, deterministic=deterministic, input_file=whitelist
+            )
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
 
@@ -126,13 +148,21 @@ class ClassifyFst(GraphFst):
 
             classify |= pynutil.add_weight(word_graph, 100)
 
-            punct = pynutil.insert("tokens { ") + pynutil.add_weight(punct_graph, weight=1.1) + pynutil.insert(" }")
+            punct = (
+                pynutil.insert("tokens { ")
+                + pynutil.add_weight(punct_graph, weight=1.1)
+                + pynutil.insert(" }")
+            )
             token = pynutil.insert("tokens { ") + classify + pynutil.insert(" }")
             token_plus_punct = (
-                pynini.closure(punct + pynutil.insert(" ")) + token + pynini.closure(pynutil.insert(" ") + punct)
+                pynini.closure(punct + pynutil.insert(" "))
+                + token
+                + pynini.closure(pynutil.insert(" ") + punct)
             )
 
-            graph = token_plus_punct + pynini.closure(pynutil.add_weight(delete_extra_space, 1.1) + token_plus_punct)
+            graph = token_plus_punct + pynini.closure(
+                (delete_extra_space).ques + token_plus_punct
+            )
             graph = delete_space + graph + delete_space
 
             self.fst = graph.optimize()

--- a/nemo_text_processing/text_normalization/de/verbalizers/electronic.py
+++ b/nemo_text_processing/text_normalization/de/verbalizers/electronic.py
@@ -38,14 +38,22 @@ class ElectronicFst(GraphFst):
     """
 
     def __init__(self, deterministic: bool = True):
-        super().__init__(name="electronic", kind="verbalize", deterministic=deterministic)
+        super().__init__(
+            name="electronic", kind="verbalize", deterministic=deterministic
+        )
         graph_digit_no_zero = pynini.invert(
             pynini.string_file(get_abs_path("data/numbers/digit.tsv"))
         ).optimize() | pynini.cross("1", "eins")
-        graph_zero = pynini.invert(pynini.string_file(get_abs_path("data/numbers/zero.tsv"))).optimize()
+        graph_zero = pynini.invert(
+            pynini.string_file(get_abs_path("data/numbers/zero.tsv"))
+        ).optimize()
         graph_digit = graph_digit_no_zero | graph_zero
-        graph_symbols = pynini.string_file(get_abs_path("data/electronic/symbols.tsv")).optimize()
-        server_common = pynini.string_file(get_abs_path("data/electronic/server_name.tsv"))
+        graph_symbols = pynini.string_file(
+            get_abs_path("data/electronic/symbols.tsv")
+        ).optimize()
+        server_common = pynini.string_file(
+            get_abs_path("data/electronic/server_name.tsv")
+        )
         domain_common = pynini.string_file(get_abs_path("data/electronic/domain.tsv"))
 
         def add_space_after_char():
@@ -53,23 +61,33 @@ class ElectronicFst(GraphFst):
                 NEMO_NOT_QUOTE - pynini.accep(" ")
             )
 
-        verbalize_characters = pynini.cdrewrite(graph_symbols | graph_digit, "", "", NEMO_SIGMA)
+        verbalize_characters = pynini.cdrewrite(
+            graph_symbols | graph_digit, "", "", NEMO_SIGMA
+        )
 
-        user_name = pynutil.delete("username: \"") + add_space_after_char() + pynutil.delete("\"")
+        user_name = (
+            pynutil.delete('username: "') + add_space_after_char() + pynutil.delete('"')
+        )
         user_name @= verbalize_characters
 
-        convert_defaults = pynutil.add_weight(NEMO_NOT_QUOTE, weight=0.0001) | domain_common | server_common
+        convert_defaults = (
+            pynutil.add_weight(NEMO_NOT_QUOTE, weight=0.0001)
+            | domain_common
+            | server_common
+        )
         domain = convert_defaults + pynini.closure(insert_space + convert_defaults)
         domain @= verbalize_characters
 
-        domain = pynutil.delete("domain: \"") + domain + pynutil.delete("\"")
+        domain = pynutil.delete('domain: "') + domain + pynutil.delete('"')
         protocol = (
-            pynutil.delete("protocol: \"")
-            + add_space_after_char() @ pynini.cdrewrite(graph_symbols, "", "", NEMO_SIGMA)
-            + pynutil.delete("\"")
+            pynutil.delete('protocol: "')
+            + add_space_after_char()
+            @ pynini.cdrewrite(graph_symbols, "", "", NEMO_SIGMA)
+            + pynutil.delete('"')
         )
         self.graph = (pynini.closure(protocol + pynini.accep(" "), 0, 1) + domain) | (
             user_name + pynini.accep(" ") + pynutil.insert("at ") + domain
+            | (pynutil.insert("at ") + user_name)
         )
         delete_tokens = self.delete_tokens(self.graph + delete_preserve_order)
         self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/fr/data/whitelist.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/whitelist.tsv
@@ -10,3 +10,4 @@ apr. J.-C.	après jésus-christ
 av. J.-C.	avant Jésus-Christ
 le hon.	l’honorable
 le très hon.	le très hononrable
+%	pour cent

--- a/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
@@ -24,9 +24,7 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_space,
     generator_main,
 )
-from nemo_text_processing.text_normalization.en.taggers.punctuation import (
-    PunctuationFst,
-)
+from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
 from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
 from nemo_text_processing.text_normalization.fr.taggers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.taggers.fraction import FractionFst
@@ -58,16 +56,13 @@ class ClassifyFst(GraphFst):
         overwrite_cache: bool = False,
         whitelist: str = None,
     ):
-        super().__init__(
-            name="tokenize_and_classify", kind="classify", deterministic=deterministic
-        )
+        super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
             far_file = os.path.join(
-                cache_dir,
-                f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
+                cache_dir, f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -78,26 +73,16 @@ class ClassifyFst(GraphFst):
             self.cardinal = CardinalFst(deterministic=deterministic)
             cardinal_graph = self.cardinal.fst
 
-            self.ordinal = OrdinalFst(
-                cardinal=self.cardinal, deterministic=deterministic
-            )
+            self.ordinal = OrdinalFst(cardinal=self.cardinal, deterministic=deterministic)
             ordinal_graph = self.ordinal.fst
 
-            self.decimal = DecimalFst(
-                cardinal=self.cardinal, deterministic=deterministic
-            )
+            self.decimal = DecimalFst(cardinal=self.cardinal, deterministic=deterministic)
             decimal_graph = self.decimal.fst
 
-            self.fraction = FractionFst(
-                cardinal=self.cardinal,
-                ordinal=self.ordinal,
-                deterministic=deterministic,
-            )
+            self.fraction = FractionFst(cardinal=self.cardinal, ordinal=self.ordinal, deterministic=deterministic,)
             fraction_graph = self.fraction.fst
             word_graph = WordFst(deterministic=deterministic).fst
-            self.whitelist = WhiteListFst(
-                input_case=input_case, deterministic=deterministic, input_file=whitelist
-            )
+            self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
 
@@ -109,11 +94,7 @@ class ClassifyFst(GraphFst):
                 | pynutil.add_weight(decimal_graph, 1.1)
                 | pynutil.add_weight(word_graph, 200)
             )
-            punct = (
-                pynutil.insert("tokens { ")
-                + pynutil.add_weight(punct_graph, weight=2.1)
-                + pynutil.insert(" }")
-            )
+            punct = pynutil.insert("tokens { ") + pynutil.add_weight(punct_graph, weight=2.1) + pynutil.insert(" }")
             punct = pynini.closure(
                 pynini.compose(pynini.closure(NEMO_WHITE_SPACE, 1), delete_extra_space)
                 | (pynutil.insert(" ") + punct),
@@ -121,14 +102,10 @@ class ClassifyFst(GraphFst):
             )
             token = pynutil.insert("tokens { ") + classify + pynutil.insert(" }")
             token_plus_punct = (
-                pynini.closure(punct + pynutil.insert(" "))
-                + token
-                + pynini.closure(pynutil.insert(" ") + punct)
+                pynini.closure(punct + pynutil.insert(" ")) + token + pynini.closure(pynutil.insert(" ") + punct)
             )
 
-            graph = token_plus_punct + pynini.closure(
-                (delete_extra_space).ques + token_plus_punct
-            )
+            graph = token_plus_punct + pynini.closure((delete_extra_space).ques + token_plus_punct)
             graph = delete_space + graph + delete_space
             graph |= punct
 

--- a/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
@@ -24,7 +24,9 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_space,
     generator_main,
 )
-from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
+from nemo_text_processing.text_normalization.en.taggers.punctuation import (
+    PunctuationFst,
+)
 from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
 from nemo_text_processing.text_normalization.fr.taggers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.taggers.fraction import FractionFst
@@ -56,13 +58,16 @@ class ClassifyFst(GraphFst):
         overwrite_cache: bool = False,
         whitelist: str = None,
     ):
-        super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
+        super().__init__(
+            name="tokenize_and_classify", kind="classify", deterministic=deterministic
+        )
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
             far_file = os.path.join(
-                cache_dir, f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
+                cache_dir,
+                f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -73,16 +78,26 @@ class ClassifyFst(GraphFst):
             self.cardinal = CardinalFst(deterministic=deterministic)
             cardinal_graph = self.cardinal.fst
 
-            self.ordinal = OrdinalFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.ordinal = OrdinalFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             ordinal_graph = self.ordinal.fst
 
-            self.decimal = DecimalFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.decimal = DecimalFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             decimal_graph = self.decimal.fst
 
-            self.fraction = FractionFst(cardinal=self.cardinal, ordinal=self.ordinal, deterministic=deterministic,)
+            self.fraction = FractionFst(
+                cardinal=self.cardinal,
+                ordinal=self.ordinal,
+                deterministic=deterministic,
+            )
             fraction_graph = self.fraction.fst
             word_graph = WordFst(deterministic=deterministic).fst
-            self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
+            self.whitelist = WhiteListFst(
+                input_case=input_case, deterministic=deterministic, input_file=whitelist
+            )
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
 
@@ -94,7 +109,11 @@ class ClassifyFst(GraphFst):
                 | pynutil.add_weight(decimal_graph, 1.1)
                 | pynutil.add_weight(word_graph, 200)
             )
-            punct = pynutil.insert("tokens { ") + pynutil.add_weight(punct_graph, weight=2.1) + pynutil.insert(" }")
+            punct = (
+                pynutil.insert("tokens { ")
+                + pynutil.add_weight(punct_graph, weight=2.1)
+                + pynutil.insert(" }")
+            )
             punct = pynini.closure(
                 pynini.compose(pynini.closure(NEMO_WHITE_SPACE, 1), delete_extra_space)
                 | (pynutil.insert(" ") + punct),
@@ -102,11 +121,14 @@ class ClassifyFst(GraphFst):
             )
             token = pynutil.insert("tokens { ") + classify + pynutil.insert(" }")
             token_plus_punct = (
-                pynini.closure(punct + pynutil.insert(" ")) + token + pynini.closure(pynutil.insert(" ") + punct)
+                pynini.closure(punct + pynutil.insert(" "))
+                + token
+                + pynini.closure(pynutil.insert(" ") + punct)
             )
 
-            graph = token_plus_punct + pynini.closure((delete_extra_space).ques + token_plus_punct)
-
+            graph = token_plus_punct + pynini.closure(
+                (delete_extra_space).ques + token_plus_punct
+            )
             graph = delete_space + graph + delete_space
             graph |= punct
 

--- a/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
@@ -24,9 +24,7 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_space,
     generator_main,
 )
-from nemo_text_processing.text_normalization.en.taggers.punctuation import (
-    PunctuationFst,
-)
+from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
 from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
 from nemo_text_processing.text_normalization.fr.taggers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.taggers.fraction import FractionFst
@@ -58,16 +56,13 @@ class ClassifyFst(GraphFst):
         overwrite_cache: bool = False,
         whitelist: str = None,
     ):
-        super().__init__(
-            name="tokenize_and_classify", kind="classify", deterministic=deterministic
-        )
+        super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
             far_file = os.path.join(
-                cache_dir,
-                f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
+                cache_dir, f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -78,26 +73,16 @@ class ClassifyFst(GraphFst):
             self.cardinal = CardinalFst(deterministic=deterministic)
             cardinal_graph = self.cardinal.fst
 
-            self.ordinal = OrdinalFst(
-                cardinal=self.cardinal, deterministic=deterministic
-            )
+            self.ordinal = OrdinalFst(cardinal=self.cardinal, deterministic=deterministic)
             ordinal_graph = self.ordinal.fst
 
-            self.decimal = DecimalFst(
-                cardinal=self.cardinal, deterministic=deterministic
-            )
+            self.decimal = DecimalFst(cardinal=self.cardinal, deterministic=deterministic)
             decimal_graph = self.decimal.fst
 
-            self.fraction = FractionFst(
-                cardinal=self.cardinal,
-                ordinal=self.ordinal,
-                deterministic=deterministic,
-            )
+            self.fraction = FractionFst(cardinal=self.cardinal, ordinal=self.ordinal, deterministic=deterministic,)
             fraction_graph = self.fraction.fst
             word_graph = WordFst(deterministic=deterministic).fst
-            self.whitelist = WhiteListFst(
-                input_case=input_case, deterministic=deterministic, input_file=whitelist
-            )
+            self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
 
@@ -109,11 +94,7 @@ class ClassifyFst(GraphFst):
                 | pynutil.add_weight(decimal_graph, 1.1)
                 | pynutil.add_weight(word_graph, 200)
             )
-            punct = (
-                pynutil.insert("tokens { ")
-                + pynutil.add_weight(punct_graph, weight=2.1)
-                + pynutil.insert(" }")
-            )
+            punct = pynutil.insert("tokens { ") + pynutil.add_weight(punct_graph, weight=2.1) + pynutil.insert(" }")
             punct = pynini.closure(
                 pynini.compose(pynini.closure(NEMO_WHITE_SPACE, 1), delete_extra_space)
                 | (pynutil.insert(" ") + punct),
@@ -121,14 +102,10 @@ class ClassifyFst(GraphFst):
             )
             token = pynutil.insert("tokens { ") + classify + pynutil.insert(" }")
             token_plus_punct = (
-                pynini.closure(punct + pynutil.insert(" "))
-                + token
-                + pynini.closure(pynutil.insert(" ") + punct)
+                pynini.closure(punct + pynutil.insert(" ")) + token + pynini.closure(pynutil.insert(" ") + punct)
             )
 
-            graph = token_plus_punct + pynini.closure(
-                (delete_extra_space).ques + token_plus_punct
-            )
+            graph = token_plus_punct + pynini.closure((delete_extra_space).ques + token_plus_punct)
 
             graph = delete_space + graph + delete_space
             graph |= punct

--- a/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
@@ -24,7 +24,9 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_space,
     generator_main,
 )
-from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
+from nemo_text_processing.text_normalization.en.taggers.punctuation import (
+    PunctuationFst,
+)
 from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
 from nemo_text_processing.text_normalization.fr.taggers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.taggers.fraction import FractionFst
@@ -56,13 +58,16 @@ class ClassifyFst(GraphFst):
         overwrite_cache: bool = False,
         whitelist: str = None,
     ):
-        super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
+        super().__init__(
+            name="tokenize_and_classify", kind="classify", deterministic=deterministic
+        )
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
             far_file = os.path.join(
-                cache_dir, f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far"
+                cache_dir,
+                f"_{input_case}_fr_tn_{deterministic}_deterministic{whitelist_file}.far",
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -73,16 +78,26 @@ class ClassifyFst(GraphFst):
             self.cardinal = CardinalFst(deterministic=deterministic)
             cardinal_graph = self.cardinal.fst
 
-            self.ordinal = OrdinalFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.ordinal = OrdinalFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             ordinal_graph = self.ordinal.fst
 
-            self.decimal = DecimalFst(cardinal=self.cardinal, deterministic=deterministic)
+            self.decimal = DecimalFst(
+                cardinal=self.cardinal, deterministic=deterministic
+            )
             decimal_graph = self.decimal.fst
 
-            self.fraction = FractionFst(cardinal=self.cardinal, ordinal=self.ordinal, deterministic=deterministic)
+            self.fraction = FractionFst(
+                cardinal=self.cardinal,
+                ordinal=self.ordinal,
+                deterministic=deterministic,
+            )
             fraction_graph = self.fraction.fst
             word_graph = WordFst(deterministic=deterministic).fst
-            self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
+            self.whitelist = WhiteListFst(
+                input_case=input_case, deterministic=deterministic, input_file=whitelist
+            )
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
 
@@ -94,7 +109,11 @@ class ClassifyFst(GraphFst):
                 | pynutil.add_weight(decimal_graph, 1.1)
                 | pynutil.add_weight(word_graph, 200)
             )
-            punct = pynutil.insert("tokens { ") + pynutil.add_weight(punct_graph, weight=2.1) + pynutil.insert(" }")
+            punct = (
+                pynutil.insert("tokens { ")
+                + pynutil.add_weight(punct_graph, weight=2.1)
+                + pynutil.insert(" }")
+            )
             punct = pynini.closure(
                 pynini.compose(pynini.closure(NEMO_WHITE_SPACE, 1), delete_extra_space)
                 | (pynutil.insert(" ") + punct),
@@ -102,15 +121,13 @@ class ClassifyFst(GraphFst):
             )
             token = pynutil.insert("tokens { ") + classify + pynutil.insert(" }")
             token_plus_punct = (
-                pynini.closure(punct + pynutil.insert(" ")) + token + pynini.closure(pynutil.insert(" ") + punct)
+                pynini.closure(punct + pynutil.insert(" "))
+                + token
+                + pynini.closure(pynutil.insert(" ") + punct)
             )
 
             graph = token_plus_punct + pynini.closure(
-                (
-                    pynini.compose(pynini.closure(NEMO_WHITE_SPACE, 1), delete_extra_space)
-                    | (pynutil.insert(" ") + punct + pynutil.insert(" "))
-                )
-                + token_plus_punct
+                (delete_extra_space).ques + token_plus_punct
             )
 
             graph = delete_space + graph + delete_space

--- a/tests/nemo_text_processing/de/data_text_normalization/test_cases_decimal.txt
+++ b/tests/nemo_text_processing/de/data_text_normalization/test_cases_decimal.txt
@@ -5,3 +5,6 @@ ein hundert zwanzig millionen~120 millionen
 zehn millionen~10 millionen
 minus sechzig komma zwei vier null null~-60,2400
 acht hundert achtzehn komma drei null drei~818,303
+eins , zwei komma drei~1,2,3
+eins komma zwei , drei komma vier~1,2,3,4
+eins , zwei komma drei , vier komma fünf~1,2,3,4,5

--- a/tests/nemo_text_processing/de/data_text_normalization/test_cases_electronic.txt
+++ b/tests/nemo_text_processing/de/data_text_normalization/test_cases_electronic.txt
@@ -7,3 +7,7 @@ a b drei bindestrich s d d bindestrich drei at g mail punkt com~ab3-sdd-3@gmail.
 h t t p s doppelpunkt slash slash w w w punkt a b c punkt com~https://www.abc.com
 w w w punkt a b c punkt com~www.abc.com
 h t t p s doppelpunkt slash slash w w w punkt a b c punkt com slash a b fragezeichen gleichheitszeichen drei bindestrich slash a b s slash eins~https://www.abc.com/ab?=3-/abs/1
+at z u c k~@zuck
+at z o o b e r e q~@zoobereq
+at z u b e r e k punkt n e t~@zuberek.net
+at w e z y r eins neun acht sechs~@wezyr1986

--- a/tests/nemo_text_processing/de/data_text_normalization/test_cases_electronic.txt
+++ b/tests/nemo_text_processing/de/data_text_normalization/test_cases_electronic.txt
@@ -6,6 +6,9 @@ a eins b zwei at a b c punkt com~a1b2@abc.com
 a b drei bindestrich s d d bindestrich drei at g mail punkt com~ab3-sdd-3@gmail.com
 h t t p s doppelpunkt slash slash w w w punkt a b c punkt com~https://www.abc.com
 w w w punkt a b c punkt com~www.abc.com
+b r e t t s p i e l v e r s a n d punkt de .~brettspielversand.de.
+w w w punkt z u b e r e k punkt net .~www.zuberek.net.
+w w w punkt a m a z o n punkt com punkt de .~www.amazon.com.de.
 h t t p s doppelpunkt slash slash w w w punkt a b c punkt com slash a b fragezeichen gleichheitszeichen drei bindestrich slash a b s slash eins~https://www.abc.com/ab?=3-/abs/1
 at z u c k~@zuck
 at z o o b e r e q~@zoobereq

--- a/tests/nemo_text_processing/de/data_text_normalization/test_cases_time.txt
+++ b/tests/nemo_text_processing/de/data_text_normalization/test_cases_time.txt
@@ -24,3 +24,5 @@ vier und zwanzig uhr fünfzehn~24:15 Uhr
 null uhr null minuten null sekunden~00:00:00 Uhr
 ein uhr eine minute eine sekunde e s t~01:01:01 Uhr est
 zwei uhr zwei minuten drei und zwanzig sekunden~02:02:23 Uhr
+zwei uhr dreißig~2.30 Uhr
+zwei uhr dreißig~02.30 Uhr

--- a/tests/nemo_text_processing/de/test_sparrowhawk_normalization.sh
+++ b/tests/nemo_text_processing/de/test_sparrowhawk_normalization.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 GRAMMARS_DIR=${1:-"/workspace/sparrowhawk/documentation/grammars"}
-PROJECT_DIR=${2:-"/workspace/tests/en"}
+PROJECT_DIR=${2:-"/workspace/tests/"}
 
 runtest () {
   input=$1

--- a/tests/nemo_text_processing/fr/data_text_normalization/test_cases_whitelist.txt
+++ b/tests/nemo_text_processing/fr/data_text_normalization/test_cases_whitelist.txt
@@ -4,3 +4,4 @@ Mᵐᵉ~madame
 Mᵐᵉˢ~mesdames
 Mˡˡᵉ~mademoiselle
 Mˡˡᵉˢ~mademoiselles
+18%~dix huit puour cent


### PR DESCRIPTION
# What does this PR do ?

- The `%` sign is now accepted by French TN ([this issue](https://github.com/NVIDIA/NeMo-text-processing/issues/171)). This is generally implemented as part of the `Measures` class, which French currently lacks. As a stop-gap measure, the `%` was whitelisted. It should be properly implemented as part of `Measures`.

This PR *does not* address the following:

- The issue with `2`h not normalizing to `deux heures` in FR. Since the abbreviation `h` is subject to declension, this problem should be addressed with the implementation of the `Measures` class. 


###  IMPORTANT!
This PR has not been tested for `pytest` or `sparrowhawk` as my machine doesn't have sufficient resources to run these tests for French.  The the FR Normalizer has been run on a gamut of strings containing the `%` resulting in correct normalization.  This fix needs testing before merging.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [ ] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [x] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [x] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [x] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [x] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [x] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [x] Remove import guards (`try import: ... except: ...`) if not already done.
- [x] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [x] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [x] Test

If you haven't finished some of the above items you can still open "Draft" PR.
