### PR TITLE
IT TN Fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     VI_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-08-23-0'
     SV_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-08-23-0'
     ZH_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/04-30-24-0'
-    IT_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/10-26-23-0'
+    IT_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-03-24-0'
     HY_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/03-12-24-0'
     MR_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/03-12-24-1'
     DEFAULT_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-08-23-0'

--- a/nemo_text_processing/text_normalization/it/data/measure/measurements.tsv
+++ b/nemo_text_processing/text_normalization/it/data/measure/measurements.tsv
@@ -61,3 +61,4 @@ dl	decilitro
 bar	bar
 kcal	chilocaloria
 cal	caloria
+%	percento

--- a/tests/nemo_text_processing/it/data_text_normalization/test_cases_measure.txt
+++ b/tests/nemo_text_processing/it/data_text_normalization/test_cases_measure.txt
@@ -4,3 +4,4 @@
 5 km/s~cinque chilometri per secondo
 15 A~quindici ampere
 155 d~cento cinquantacinque giorni
+il 18% delle emissioni di carbonio~il diciotto percento delle emissioni di carbonio

--- a/tests/nemo_text_processing/it/test_sparrowhawk_normalization.sh
+++ b/tests/nemo_text_processing/it/test_sparrowhawk_normalization.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 PGRAMMARS_DIR=${1:-"/workspace/sparrowhawk/documentation/grammars"}
-PROJECT_DIR=${2:-"/workspace/tests/en"}
+PROJECT_DIR=${2:-"/workspace/tests/"}
 
 runtest () {
   input=$1


### PR DESCRIPTION
# What does this PR do ?

The `%` sign is now accepted by Italian TN (see [this issue](https://github.com/NVIDIA/NeMo-text-processing/issues/171)).
The implementation passes all `pyTest`s but **fails a handful of `Sparrowhawk` tests**.  Since the current fix adds a single mapping, to `nemo_text_processing/text_normalization/it/data/measure/measurements.tsv`, it is unlikely to be related to `Sparrowhawk` failures.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [x] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [x] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [x] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [x] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [x] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [x] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [x] Remove import guards (`try import: ... except: ...`) if not already done.
- [x] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [x] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [x] Test

If you haven't finished some of the above items you can still open "Draft" PR.
