### PR TITLE
Fix for nv-bug 4786175

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
     AR_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/04-24-24-0'
     DE_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-03-24-0'
-    EN_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/08-15-24-0'
+    EN_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/08-20-24-0'
     ES_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/08-14-24-0'
     ES_EN_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/08-14-24-0'
     FR_TN_CACHE='/home/jenkinsci/TestData/text_norm/ci/grammars/06-04-24-0'

--- a/nemo_text_processing/text_normalization/en/data/measure/unit.tsv
+++ b/nemo_text_processing/text_normalization/en/data/measure/unit.tsv
@@ -125,3 +125,11 @@ s	S
 tb	TB
 tb	YB
 zb	ZB
+sec	second
+min	minute
+hr	hour
+d	day
+wk	week
+mo	month
+yr	year
+svc	service

--- a/nemo_text_processing/text_normalization/en/data/money/per_unit.tsv
+++ b/nemo_text_processing/text_normalization/en/data/money/per_unit.tsv
@@ -1,2 +1,11 @@
 /ea	each
-/dozen
+/dozen	per dozen
+/sec	per second
+/min	per minute
+/hr	per hour
+/h	per hour
+/d	per day
+/wk	per week
+/mo	per month
+/yr	per year
+/svc	per service

--- a/nemo_text_processing/text_normalization/en/taggers/money.py
+++ b/nemo_text_processing/text_normalization/en/taggers/money.py
@@ -26,14 +26,17 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
 )
 from nemo_text_processing.text_normalization.en.utils import get_abs_path, load_labels
 
-min_singular = pynini.string_file(get_abs_path("data/money/currency_minor_singular.tsv"))
+min_singular = pynini.string_file(
+    get_abs_path("data/money/currency_minor_singular.tsv")
+)
 min_plural = pynini.string_file(get_abs_path("data/money/currency_minor_plural.tsv"))
 maj_singular = pynini.string_file((get_abs_path("data/money/currency_major.tsv")))
+per_units = pynini.string_file(get_abs_path("data/money/per_unit.tsv"))
 
 
 class MoneyFst(GraphFst):
     """
-    Finite state transducer for classifying money, suppletive aware, e.g. 
+    Finite state transducer for classifying money, suppletive aware, e.g.
         $12.05 -> money { integer_part: "twelve" currency_maj: "dollars" fractional_part: "five" currency_min: "cents" preserve_order: true }
         $12.0500 -> money { integer_part: "twelve" currency_maj: "dollars" fractional_part: "five" currency_min: "cents" preserve_order: true }
         $1 -> money { currency_maj: "dollar" integer_part: "one" }
@@ -50,7 +53,9 @@ class MoneyFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal: GraphFst, decimal: GraphFst, deterministic: bool = True):
+    def __init__(
+        self, cardinal: GraphFst, decimal: GraphFst, deterministic: bool = True
+    ):
         super().__init__(name="money", kind="classify", deterministic=deterministic)
         cardinal_graph = cardinal.graph_with_and
         graph_decimal_final = decimal.final_graph_wo_negative_w_abbr
@@ -59,14 +64,22 @@ class MoneyFst(GraphFst):
         maj_unit_plural = convert_space(maj_singular @ SINGULAR_TO_PLURAL)
         maj_unit_singular = convert_space(maj_singular)
 
-        graph_maj_singular = pynutil.insert("currency_maj: \"") + maj_unit_singular + pynutil.insert("\"")
-        graph_maj_plural = pynutil.insert("currency_maj: \"") + maj_unit_plural + pynutil.insert("\"")
+        graph_maj_singular = (
+            pynutil.insert('currency_maj: "') + maj_unit_singular + pynutil.insert('"')
+        )
+        graph_maj_plural = (
+            pynutil.insert('currency_maj: "') + maj_unit_plural + pynutil.insert('"')
+        )
 
         optional_delete_fractional_zeros = pynini.closure(
             pynutil.delete(".") + pynini.closure(pynutil.delete("0"), 1), 0, 1
         )
 
-        graph_integer_one = pynutil.insert("integer_part: \"") + pynini.cross("1", "one") + pynutil.insert("\"")
+        graph_integer_one = (
+            pynutil.insert('integer_part: "')
+            + pynini.cross("1", "one")
+            + pynutil.insert('"')
+        )
         # only for decimals where third decimal after comma is non-zero or with quantity
         decimal_delete_last_zeros = (
             pynini.closure(NEMO_DIGIT | pynutil.delete(","))
@@ -78,83 +91,131 @@ class MoneyFst(GraphFst):
         decimal_with_quantity = NEMO_SIGMA + NEMO_ALPHA
 
         graph_decimal = (
-            graph_maj_plural + insert_space + (decimal_delete_last_zeros | decimal_with_quantity) @ graph_decimal_final
+            graph_maj_plural
+            + insert_space
+            + (decimal_delete_last_zeros | decimal_with_quantity) @ graph_decimal_final
         )
 
         graph_integer = (
-            pynutil.insert("integer_part: \"") + ((NEMO_SIGMA - "1") @ cardinal_graph) + pynutil.insert("\"")
+            pynutil.insert('integer_part: "')
+            + ((NEMO_SIGMA - "1") @ cardinal_graph)
+            + pynutil.insert('"')
         )
 
         graph_integer_only = graph_maj_singular + insert_space + graph_integer_one
         graph_integer_only |= graph_maj_plural + insert_space + graph_integer
 
-        final_graph = (graph_integer_only + optional_delete_fractional_zeros) | graph_decimal
+        final_graph = (
+            graph_integer_only + optional_delete_fractional_zeros
+        ) | graph_decimal
 
         # remove trailing zeros of non zero number in the first 2 digits and fill up to 2 digits
         # e.g. 2000 -> 20, 0200->02, 01 -> 01, 10 -> 10
         # not accepted: 002, 00, 0,
         two_digits_fractional_part = (
-            pynini.closure(NEMO_DIGIT) + (NEMO_DIGIT - "0") + pynini.closure(pynutil.delete("0"))
+            pynini.closure(NEMO_DIGIT)
+            + (NEMO_DIGIT - "0")
+            + pynini.closure(pynutil.delete("0"))
         ) @ (
             (pynutil.delete("0") + (NEMO_DIGIT - "0"))
             | ((NEMO_DIGIT - "0") + pynutil.insert("0"))
             | ((NEMO_DIGIT - "0") + NEMO_DIGIT)
         )
 
-        graph_min_singular = pynutil.insert(" currency_min: \"") + min_singular + pynutil.insert("\"")
-        graph_min_plural = pynutil.insert(" currency_min: \"") + min_plural + pynutil.insert("\"")
+        graph_min_singular = (
+            pynutil.insert(' currency_min: "') + min_singular + pynutil.insert('"')
+        )
+        graph_min_plural = (
+            pynutil.insert(' currency_min: "') + min_plural + pynutil.insert('"')
+        )
         # format ** dollars ** cent
         decimal_graph_with_minor = None
         integer_graph_reordered = None
         decimal_default_reordered = None
         for curr_symbol, _ in maj_singular_labels:
             preserve_order = pynutil.insert(" preserve_order: true")
-            integer_plus_maj = graph_integer + insert_space + pynutil.insert(curr_symbol) @ graph_maj_plural
-            integer_plus_maj |= graph_integer_one + insert_space + pynutil.insert(curr_symbol) @ graph_maj_singular
+            integer_plus_maj = (
+                graph_integer
+                + insert_space
+                + pynutil.insert(curr_symbol) @ graph_maj_plural
+            )
+            integer_plus_maj |= (
+                graph_integer_one
+                + insert_space
+                + pynutil.insert(curr_symbol) @ graph_maj_singular
+            )
 
             integer_plus_maj_with_comma = pynini.compose(
-                NEMO_DIGIT - "0" + pynini.closure(NEMO_DIGIT | pynutil.delete(",")), integer_plus_maj
+                NEMO_DIGIT - "0" + pynini.closure(NEMO_DIGIT | pynutil.delete(",")),
+                integer_plus_maj,
             )
-            integer_plus_maj = pynini.compose(pynini.closure(NEMO_DIGIT) - "0", integer_plus_maj)
+            integer_plus_maj = pynini.compose(
+                pynini.closure(NEMO_DIGIT) - "0", integer_plus_maj
+            )
             integer_plus_maj |= integer_plus_maj_with_comma
 
             graph_fractional_one = two_digits_fractional_part @ pynini.cross("1", "one")
-            graph_fractional_one = pynutil.insert("fractional_part: \"") + graph_fractional_one + pynutil.insert("\"")
+            graph_fractional_one = (
+                pynutil.insert('fractional_part: "')
+                + graph_fractional_one
+                + pynutil.insert('"')
+            )
             graph_fractional = (
                 two_digits_fractional_part
                 @ (pynini.closure(NEMO_DIGIT, 1, 2) - "1")
                 @ cardinal.graph_hundred_component_at_least_one_none_zero_digit
             )
-            graph_fractional = pynutil.insert("fractional_part: \"") + graph_fractional + pynutil.insert("\"")
-
-            fractional_plus_min = graph_fractional + insert_space + pynutil.insert(curr_symbol) @ graph_min_plural
-            fractional_plus_min |= (
-                graph_fractional_one + insert_space + pynutil.insert(curr_symbol) @ graph_min_singular
+            graph_fractional = (
+                pynutil.insert('fractional_part: "')
+                + graph_fractional
+                + pynutil.insert('"')
             )
 
-            decimal_graph_with_minor_curr = integer_plus_maj + pynini.cross(".", " ") + fractional_plus_min
+            fractional_plus_min = (
+                graph_fractional
+                + insert_space
+                + pynutil.insert(curr_symbol) @ graph_min_plural
+            )
+            fractional_plus_min |= (
+                graph_fractional_one
+                + insert_space
+                + pynutil.insert(curr_symbol) @ graph_min_singular
+            )
+
+            decimal_graph_with_minor_curr = (
+                integer_plus_maj + pynini.cross(".", " ") + fractional_plus_min
+            )
 
             if not deterministic:
                 decimal_graph_with_minor_curr |= pynutil.add_weight(
                     integer_plus_maj
                     + pynini.cross(".", " ")
-                    + pynutil.insert("fractional_part: \"")
-                    + two_digits_fractional_part @ cardinal.graph_hundred_component_at_least_one_none_zero_digit
-                    + pynutil.insert("\""),
+                    + pynutil.insert('fractional_part: "')
+                    + two_digits_fractional_part
+                    @ cardinal.graph_hundred_component_at_least_one_none_zero_digit
+                    + pynutil.insert('"'),
                     weight=0.0001,
                 )
-                default_fraction_graph = (decimal_delete_last_zeros | decimal_with_quantity) @ graph_decimal_final
+                default_fraction_graph = (
+                    decimal_delete_last_zeros | decimal_with_quantity
+                ) @ graph_decimal_final
             decimal_graph_with_minor_curr |= (
-                pynini.closure(pynutil.delete("0"), 0, 1) + pynutil.delete(".") + fractional_plus_min
+                pynini.closure(pynutil.delete("0"), 0, 1)
+                + pynutil.delete(".")
+                + fractional_plus_min
             )
             decimal_graph_with_minor_curr = (
-                pynutil.delete(curr_symbol) + decimal_graph_with_minor_curr + preserve_order
+                pynutil.delete(curr_symbol)
+                + decimal_graph_with_minor_curr
+                + preserve_order
             )
 
             decimal_graph_with_minor = (
                 decimal_graph_with_minor_curr
                 if decimal_graph_with_minor is None
-                else pynini.union(decimal_graph_with_minor, decimal_graph_with_minor_curr).optimize()
+                else pynini.union(
+                    decimal_graph_with_minor, decimal_graph_with_minor_curr
+                ).optimize()
             )
 
             if not deterministic:
@@ -165,7 +226,9 @@ class MoneyFst(GraphFst):
                 integer_graph_reordered = (
                     integer_graph_reordered_curr
                     if integer_graph_reordered is None
-                    else pynini.union(integer_graph_reordered, integer_graph_reordered_curr).optimize()
+                    else pynini.union(
+                        integer_graph_reordered, integer_graph_reordered_curr
+                    ).optimize()
                 )
                 decimal_default_reordered_curr = (
                     pynutil.delete(curr_symbol)
@@ -177,17 +240,31 @@ class MoneyFst(GraphFst):
                 decimal_default_reordered = (
                     decimal_default_reordered_curr
                     if decimal_default_reordered is None
-                    else pynini.union(decimal_default_reordered, decimal_default_reordered_curr)
+                    else pynini.union(
+                        decimal_default_reordered, decimal_default_reordered_curr
+                    )
                 ).optimize()
 
         # weight for SH
         final_graph |= pynutil.add_weight(decimal_graph_with_minor, -0.0001)
 
+        # utilizes morphosyntactic features to append "per units"
+        graph_per_units = (
+            pynutil.insert(' morphosyntactic_features: "')
+            + per_units
+            + pynutil.insert('"')
+        )
+
         if not deterministic:
             final_graph |= integer_graph_reordered | decimal_default_reordered
             # to handle "$2.00" cases
             final_graph |= pynini.compose(
-                NEMO_SIGMA + pynutil.delete(".") + pynini.closure(pynutil.delete("0"), 1), integer_graph_reordered
+                NEMO_SIGMA
+                + pynutil.delete(".")
+                + pynini.closure(pynutil.delete("0"), 1),
+                integer_graph_reordered,
             )
+
+        final_graph += graph_per_units.ques
         final_graph = self.add_tokens(final_graph.optimize())
         self.fst = final_graph.optimize()

--- a/nemo_text_processing/text_normalization/en/taggers/money.py
+++ b/nemo_text_processing/text_normalization/en/taggers/money.py
@@ -26,9 +26,7 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
 )
 from nemo_text_processing.text_normalization.en.utils import get_abs_path, load_labels
 
-min_singular = pynini.string_file(
-    get_abs_path("data/money/currency_minor_singular.tsv")
-)
+min_singular = pynini.string_file(get_abs_path("data/money/currency_minor_singular.tsv"))
 min_plural = pynini.string_file(get_abs_path("data/money/currency_minor_plural.tsv"))
 maj_singular = pynini.string_file((get_abs_path("data/money/currency_major.tsv")))
 per_units = pynini.string_file(get_abs_path("data/money/per_unit.tsv"))
@@ -53,9 +51,7 @@ class MoneyFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(
-        self, cardinal: GraphFst, decimal: GraphFst, deterministic: bool = True
-    ):
+    def __init__(self, cardinal: GraphFst, decimal: GraphFst, deterministic: bool = True):
         super().__init__(name="money", kind="classify", deterministic=deterministic)
         cardinal_graph = cardinal.graph_with_and
         graph_decimal_final = decimal.final_graph_wo_negative_w_abbr
@@ -64,22 +60,14 @@ class MoneyFst(GraphFst):
         maj_unit_plural = convert_space(maj_singular @ SINGULAR_TO_PLURAL)
         maj_unit_singular = convert_space(maj_singular)
 
-        graph_maj_singular = (
-            pynutil.insert('currency_maj: "') + maj_unit_singular + pynutil.insert('"')
-        )
-        graph_maj_plural = (
-            pynutil.insert('currency_maj: "') + maj_unit_plural + pynutil.insert('"')
-        )
+        graph_maj_singular = pynutil.insert('currency_maj: "') + maj_unit_singular + pynutil.insert('"')
+        graph_maj_plural = pynutil.insert('currency_maj: "') + maj_unit_plural + pynutil.insert('"')
 
         optional_delete_fractional_zeros = pynini.closure(
             pynutil.delete(".") + pynini.closure(pynutil.delete("0"), 1), 0, 1
         )
 
-        graph_integer_one = (
-            pynutil.insert('integer_part: "')
-            + pynini.cross("1", "one")
-            + pynutil.insert('"')
-        )
+        graph_integer_one = pynutil.insert('integer_part: "') + pynini.cross("1", "one") + pynutil.insert('"')
         # only for decimals where third decimal after comma is non-zero or with quantity
         decimal_delete_last_zeros = (
             pynini.closure(NEMO_DIGIT | pynutil.delete(","))
@@ -91,131 +79,81 @@ class MoneyFst(GraphFst):
         decimal_with_quantity = NEMO_SIGMA + NEMO_ALPHA
 
         graph_decimal = (
-            graph_maj_plural
-            + insert_space
-            + (decimal_delete_last_zeros | decimal_with_quantity) @ graph_decimal_final
+            graph_maj_plural + insert_space + (decimal_delete_last_zeros | decimal_with_quantity) @ graph_decimal_final
         )
 
-        graph_integer = (
-            pynutil.insert('integer_part: "')
-            + ((NEMO_SIGMA - "1") @ cardinal_graph)
-            + pynutil.insert('"')
-        )
+        graph_integer = pynutil.insert('integer_part: "') + ((NEMO_SIGMA - "1") @ cardinal_graph) + pynutil.insert('"')
 
         graph_integer_only = graph_maj_singular + insert_space + graph_integer_one
         graph_integer_only |= graph_maj_plural + insert_space + graph_integer
 
-        final_graph = (
-            graph_integer_only + optional_delete_fractional_zeros
-        ) | graph_decimal
+        final_graph = (graph_integer_only + optional_delete_fractional_zeros) | graph_decimal
 
         # remove trailing zeros of non zero number in the first 2 digits and fill up to 2 digits
         # e.g. 2000 -> 20, 0200->02, 01 -> 01, 10 -> 10
         # not accepted: 002, 00, 0,
         two_digits_fractional_part = (
-            pynini.closure(NEMO_DIGIT)
-            + (NEMO_DIGIT - "0")
-            + pynini.closure(pynutil.delete("0"))
+            pynini.closure(NEMO_DIGIT) + (NEMO_DIGIT - "0") + pynini.closure(pynutil.delete("0"))
         ) @ (
             (pynutil.delete("0") + (NEMO_DIGIT - "0"))
             | ((NEMO_DIGIT - "0") + pynutil.insert("0"))
             | ((NEMO_DIGIT - "0") + NEMO_DIGIT)
         )
 
-        graph_min_singular = (
-            pynutil.insert(' currency_min: "') + min_singular + pynutil.insert('"')
-        )
-        graph_min_plural = (
-            pynutil.insert(' currency_min: "') + min_plural + pynutil.insert('"')
-        )
+        graph_min_singular = pynutil.insert(' currency_min: "') + min_singular + pynutil.insert('"')
+        graph_min_plural = pynutil.insert(' currency_min: "') + min_plural + pynutil.insert('"')
         # format ** dollars ** cent
         decimal_graph_with_minor = None
         integer_graph_reordered = None
         decimal_default_reordered = None
         for curr_symbol, _ in maj_singular_labels:
             preserve_order = pynutil.insert(" preserve_order: true")
-            integer_plus_maj = (
-                graph_integer
-                + insert_space
-                + pynutil.insert(curr_symbol) @ graph_maj_plural
-            )
-            integer_plus_maj |= (
-                graph_integer_one
-                + insert_space
-                + pynutil.insert(curr_symbol) @ graph_maj_singular
-            )
+            integer_plus_maj = graph_integer + insert_space + pynutil.insert(curr_symbol) @ graph_maj_plural
+            integer_plus_maj |= graph_integer_one + insert_space + pynutil.insert(curr_symbol) @ graph_maj_singular
 
             integer_plus_maj_with_comma = pynini.compose(
-                NEMO_DIGIT - "0" + pynini.closure(NEMO_DIGIT | pynutil.delete(",")),
-                integer_plus_maj,
+                NEMO_DIGIT - "0" + pynini.closure(NEMO_DIGIT | pynutil.delete(",")), integer_plus_maj,
             )
-            integer_plus_maj = pynini.compose(
-                pynini.closure(NEMO_DIGIT) - "0", integer_plus_maj
-            )
+            integer_plus_maj = pynini.compose(pynini.closure(NEMO_DIGIT) - "0", integer_plus_maj)
             integer_plus_maj |= integer_plus_maj_with_comma
 
             graph_fractional_one = two_digits_fractional_part @ pynini.cross("1", "one")
-            graph_fractional_one = (
-                pynutil.insert('fractional_part: "')
-                + graph_fractional_one
-                + pynutil.insert('"')
-            )
+            graph_fractional_one = pynutil.insert('fractional_part: "') + graph_fractional_one + pynutil.insert('"')
             graph_fractional = (
                 two_digits_fractional_part
                 @ (pynini.closure(NEMO_DIGIT, 1, 2) - "1")
                 @ cardinal.graph_hundred_component_at_least_one_none_zero_digit
             )
-            graph_fractional = (
-                pynutil.insert('fractional_part: "')
-                + graph_fractional
-                + pynutil.insert('"')
-            )
+            graph_fractional = pynutil.insert('fractional_part: "') + graph_fractional + pynutil.insert('"')
 
-            fractional_plus_min = (
-                graph_fractional
-                + insert_space
-                + pynutil.insert(curr_symbol) @ graph_min_plural
-            )
+            fractional_plus_min = graph_fractional + insert_space + pynutil.insert(curr_symbol) @ graph_min_plural
             fractional_plus_min |= (
-                graph_fractional_one
-                + insert_space
-                + pynutil.insert(curr_symbol) @ graph_min_singular
+                graph_fractional_one + insert_space + pynutil.insert(curr_symbol) @ graph_min_singular
             )
 
-            decimal_graph_with_minor_curr = (
-                integer_plus_maj + pynini.cross(".", " ") + fractional_plus_min
-            )
+            decimal_graph_with_minor_curr = integer_plus_maj + pynini.cross(".", " ") + fractional_plus_min
 
             if not deterministic:
                 decimal_graph_with_minor_curr |= pynutil.add_weight(
                     integer_plus_maj
                     + pynini.cross(".", " ")
                     + pynutil.insert('fractional_part: "')
-                    + two_digits_fractional_part
-                    @ cardinal.graph_hundred_component_at_least_one_none_zero_digit
+                    + two_digits_fractional_part @ cardinal.graph_hundred_component_at_least_one_none_zero_digit
                     + pynutil.insert('"'),
                     weight=0.0001,
                 )
-                default_fraction_graph = (
-                    decimal_delete_last_zeros | decimal_with_quantity
-                ) @ graph_decimal_final
+                default_fraction_graph = (decimal_delete_last_zeros | decimal_with_quantity) @ graph_decimal_final
             decimal_graph_with_minor_curr |= (
-                pynini.closure(pynutil.delete("0"), 0, 1)
-                + pynutil.delete(".")
-                + fractional_plus_min
+                pynini.closure(pynutil.delete("0"), 0, 1) + pynutil.delete(".") + fractional_plus_min
             )
             decimal_graph_with_minor_curr = (
-                pynutil.delete(curr_symbol)
-                + decimal_graph_with_minor_curr
-                + preserve_order
+                pynutil.delete(curr_symbol) + decimal_graph_with_minor_curr + preserve_order
             )
 
             decimal_graph_with_minor = (
                 decimal_graph_with_minor_curr
                 if decimal_graph_with_minor is None
-                else pynini.union(
-                    decimal_graph_with_minor, decimal_graph_with_minor_curr
-                ).optimize()
+                else pynini.union(decimal_graph_with_minor, decimal_graph_with_minor_curr).optimize()
             )
 
             if not deterministic:
@@ -226,9 +164,7 @@ class MoneyFst(GraphFst):
                 integer_graph_reordered = (
                     integer_graph_reordered_curr
                     if integer_graph_reordered is None
-                    else pynini.union(
-                        integer_graph_reordered, integer_graph_reordered_curr
-                    ).optimize()
+                    else pynini.union(integer_graph_reordered, integer_graph_reordered_curr).optimize()
                 )
                 decimal_default_reordered_curr = (
                     pynutil.delete(curr_symbol)
@@ -240,29 +176,20 @@ class MoneyFst(GraphFst):
                 decimal_default_reordered = (
                     decimal_default_reordered_curr
                     if decimal_default_reordered is None
-                    else pynini.union(
-                        decimal_default_reordered, decimal_default_reordered_curr
-                    )
+                    else pynini.union(decimal_default_reordered, decimal_default_reordered_curr)
                 ).optimize()
 
         # weight for SH
         final_graph |= pynutil.add_weight(decimal_graph_with_minor, -0.0001)
 
         # utilizes morphosyntactic features to append "per units"
-        graph_per_units = (
-            pynutil.insert(' morphosyntactic_features: "')
-            + per_units
-            + pynutil.insert('"')
-        )
+        graph_per_units = pynutil.insert(' morphosyntactic_features: "') + per_units + pynutil.insert('"')
 
         if not deterministic:
             final_graph |= integer_graph_reordered | decimal_default_reordered
             # to handle "$2.00" cases
             final_graph |= pynini.compose(
-                NEMO_SIGMA
-                + pynutil.delete(".")
-                + pynini.closure(pynutil.delete("0"), 1),
-                integer_graph_reordered,
+                NEMO_SIGMA + pynutil.delete(".") + pynini.closure(pynutil.delete("0"), 1), integer_graph_reordered,
             )
 
         final_graph += graph_per_units.ques

--- a/nemo_text_processing/text_normalization/en/verbalizers/money.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/money.py
@@ -41,21 +41,11 @@ class MoneyFst(GraphFst):
     def __init__(self, decimal: GraphFst, deterministic: bool = True):
         super().__init__(name="money", kind="verbalize", deterministic=deterministic)
         keep_space = pynini.accep(" ")
-        maj = (
-            pynutil.delete('currency_maj: "')
-            + pynini.closure(NEMO_NOT_QUOTE, 1)
-            + pynutil.delete('"')
-        )
-        min = (
-            pynutil.delete('currency_min: "')
-            + pynini.closure(NEMO_NOT_QUOTE, 1)
-            + pynutil.delete('"')
-        )
+        maj = pynutil.delete('currency_maj: "') + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete('"')
+        min = pynutil.delete('currency_min: "') + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete('"')
 
         fractional_part = (
-            pynutil.delete('fractional_part: "')
-            + pynini.closure(NEMO_NOT_QUOTE, 1)
-            + pynutil.delete('"')
+            pynutil.delete('fractional_part: "') + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete('"')
         )
 
         integer_part = decimal.integer
@@ -69,14 +59,7 @@ class MoneyFst(GraphFst):
         if not deterministic:
             fractional |= pynutil.insert("and ") + fractional
 
-        graph_integer_with_minor = (
-            integer_part
-            + keep_space
-            + maj
-            + keep_space
-            + fractional
-            + delete_preserve_order
-        )
+        graph_integer_with_minor = integer_part + keep_space + maj + keep_space + fractional + delete_preserve_order
 
         # *** point *** currency_maj
         graph_decimal = decimal.numbers + keep_space + maj

--- a/tests/nemo_text_processing/en/data_text_normalization/test_cases_money.txt
+++ b/tests/nemo_text_processing/en/data_text_normalization/test_cases_money.txt
@@ -64,3 +64,8 @@ $1,234.123~one thousand two hundred and thirty four point one two three dollars
 US $76.3 trillion~US seventy six point three trillion dollars
 US$76.3 trillion~seventy six point three trillion us dollars
 The price for each canned salmon is $5 , each bottle of peanut butter is $3~The price for each canned salmon is five dollars , each bottle of peanut butter is three dollars
+$20/mo is what we are currently charging.~twenty dollars per month is what we are currently charging.
+$350/yr is the fee.~three hundred and fifty dollars per year is the fee.
+£10/wk sounds good to us.~ten pounds per week sounds good to us.
+$1/d is the new subscription cost.~one dollar per day is the new subscription cost.
+$0.5/hr is the total cost.~fifty cents per hour is the total cost.


### PR DESCRIPTION
# What does this PR do ?

Fixes [nv-bug #4786175](https://nvbugspro.nvidia.com/bug/4786175).

The fix implements `per_unit` mappings in lieu of morphosyntactic features.  The list of mappings is contained in `nemo_text_processing/text_normalization/en/data/money/per_unit.tsv` and may be expanded to include additional mappings.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [x] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [x] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [x] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [x] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [x] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [x] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [x] Remove import guards (`try import: ... except: ...`) if not already done.
- [x] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [x] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
