### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
       - id: detect-private-key
       - id: requirements-txt-fixer
 
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+        args:
+        - --select=W605
+
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/nemo_text_processing/fst_alignment/alignment.py
+++ b/nemo_text_processing/fst_alignment/alignment.py
@@ -99,7 +99,8 @@ EPS = "<eps>"
 WHITE_SPACE = "\u23B5"
 ITN_MODE = "itn"
 TN_MODE = "tn"
-tn_itn_symbols = list(string.ascii_letters + string.digits) + list("$\:+-=")
+tn_item_special_chars = ["$", "\\", ":", "+", "-", "="]
+tn_itn_symbols = list(string.ascii_letters + string.digits) + tn_item_special_chars
 
 
 def get_word_segments(text: str) -> List[List[int]]:

--- a/nemo_text_processing/hybrid/model_utils.py
+++ b/nemo_text_processing/hybrid/model_utils.py
@@ -57,15 +57,15 @@ def get_masked_score(text, model, do_lower=True):
     If multiple tokens are present, multiple variants of the text are created where all but one ambiguous semiotic tokens are masked
     to avoid unwanted reinforcement of neighboring semiotic tokens."""
     text = text.lower() if do_lower else text
-    spans = re.findall("<\s.+?\s>", text)
+    spans = re.findall(r"<\s.+?\s>", text)
     if len(spans) > 0:
         text_with_mask = []
 
-        for match in re.finditer("<\s.+?\s>", text):
+        for match in re.finditer(r"<\s.+?\s>", text):
             new_text = (
                 text[: match.span()[0]] + match.group().replace("< ", "").replace(" >", "") + text[match.span()[1] :]
             )
-            new_text = re.sub("<\s.+?\s>", model.MASK_LABEL, new_text)
+            new_text = re.sub(r"<\s.+?\s>", model.MASK_LABEL, new_text)
             text_with_mask.append(new_text)
         text = text_with_mask
 
@@ -76,9 +76,9 @@ def _get_ambiguous_positions(sentences: List[str]):
     """returns None or index list of ambigous semiotic tokens for list of sentences.
     E.g. if sentences = ["< street > < three > A", "< saint > < three > A"], it returns [1, 0] since only 
     the first semiotic span <street>/<saint> is ambiguous."""
-    l_sets = [set([x]) for x in re.findall("<\s.+?\s>", sentences[0])]
+    l_sets = [set([x]) for x in re.findall(r"<\s.+?\s>", sentences[0])]
     for sentence in sentences[1:]:
-        spans = re.findall("<\s.+?\s>", sentence)
+        spans = re.findall(r"<\s.+?\s>", sentence)
         if len(spans) != len(l_sets):
             return None
         for i in range(len(spans)):
@@ -115,7 +115,7 @@ def score_options(sentences: List[str], context_len, model, do_lower=True):
             scores.append(av_score)
         elif isinstance(sent, str):  # in case of full context
             if ambiguous_positions:
-                matches = list(re.finditer("<\s.+?\s>", sent))
+                matches = list(re.finditer(r"<\s.+?\s>", sent))
                 for match, pos in zip(matches[::-1], ambiguous_positions[::-1]):
                     if not pos:
                         sent = (

--- a/nemo_text_processing/text_normalization/en/taggers/punctuation.py
+++ b/nemo_text_processing/text_normalization/en/taggers/punctuation.py
@@ -43,7 +43,7 @@ class PunctuationFst(GraphFst):
             chr(i)
             for i in range(sys.maxunicode)
             if category(chr(i)).startswith("P") and chr(i) not in punct_symbols_to_exclude
-        ] + ["\[", "\]"]
+        ] + [r"\[", r"\]"]
 
         whitelist_symbols = load_labels(get_abs_path("data/whitelist/symbol.tsv"))
         whitelist_symbols = [x[0] for x in whitelist_symbols]

--- a/nemo_text_processing/text_normalization/en/verbalizers/post_processing.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/post_processing.py
@@ -109,7 +109,7 @@ class PostProcessingFst:
         # no_space_before_punct assume no space before them
         quotes = ["'", "\"", "``", "«"]
         dashes = ["-", "—"]
-        brackets = ["<", "{", "(", "\["]
+        brackets = ["<", "{", "(", r"\["]
         open_close_single_quotes = [
             ("`", "`"),
         ]


### PR DESCRIPTION
# What does this PR do ?

This PR fixes SyntaxError issues in Python3.12.

In python3.12, using escape sequences outside of raw strings has been [moved from a deprecation warning into a syntax error](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes), as noted in previous PRs such as #157. As such, I've added a linter to track down cases where we still have this issue and fixed all said reported issues. The original list was as follows:

```
nemo_text_processing/fst_alignment/alignment.py:102:70: W605 invalid escape sequence '\:'
nemo_text_processing/hybrid/model_utils.py:60:26: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:60:31: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:64:36: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:64:41: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:68:33: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:68:38: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:79:46: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:79:51: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:81:30: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:81:35: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:118:46: W605 invalid escape sequence '\s'
nemo_text_processing/hybrid/model_utils.py:118:51: W605 invalid escape sequence '\s'
nemo_text_processing/text_normalization/en/taggers/punctuation.py:46:15: W605 invalid escape sequence '\['
nemo_text_processing/text_normalization/en/taggers/punctuation.py:46:21: W605 invalid escape sequence '\]'
nemo_text_processing/text_normalization/en/verbalizers/post_processing.py:112:37: W605 invalid escape sequence '\['
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [x] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [ ] Test