### PR TITLE
Fixes utils in pynini_export

### DIFF
--- a/tools/text_processing_deployment/pynini_export.py
+++ b/tools/text_processing_deployment/pynini_export.py
@@ -86,9 +86,7 @@ def export_grammars(output_dir, grammars):
 
 def parse_args():
     parser = ArgumentParser()
-    parser.add_argument(
-        "--output_dir", help="output directory for grammars", required=True, type=str
-    )
+    parser.add_argument("--output_dir", help="output directory for grammars", required=True, type=str)
     parser.add_argument(
         "--language",
         help="language",
@@ -116,18 +114,10 @@ def parse_args():
         default="en",
     )
     parser.add_argument(
-        "--grammars",
-        help="grammars to be exported",
-        choices=["tn_grammars", "itn_grammars"],
-        type=str,
-        required=True,
+        "--grammars", help="grammars to be exported", choices=["tn_grammars", "itn_grammars"], type=str, required=True,
     )
     parser.add_argument(
-        "--input_case",
-        help="input capitalization",
-        choices=["lower_cased", "cased"],
-        default="cased",
-        type=str,
+        "--input_case", help="input capitalization", choices=["lower_cased", "cased"], default="cased", type=str,
     )
     parser.add_argument(
         "--whitelist",
@@ -138,9 +128,7 @@ def parse_args():
         type=lambda x: None if x == "None" else x,
     )
     parser.add_argument(
-        "--overwrite_cache",
-        help="set to True to re-create .far grammar files",
-        action="store_true",
+        "--overwrite_cache", help="set to True to re-create .far grammar files", action="store_true",
     )
     parser.add_argument(
         "--cache_dir",
@@ -154,13 +142,8 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    if (
-        args.language in ["pt", "ru", "vi", "es_en", "mr"]
-        and args.grammars == "tn_grammars"
-    ):
-        raise ValueError(
-            "Only ITN grammars could be deployed in Sparrowhawk for the selected languages."
-        )
+    if args.language in ["pt", "ru", "vi", "es_en", "mr"] and args.grammars == "tn_grammars":
+        raise ValueError("Only ITN grammars could be deployed in Sparrowhawk for the selected languages.")
     TNPostProcessingFst = None
     ITNPostProcessingFst = None
     if args.language == "en":
@@ -176,9 +159,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.en.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.en.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.en.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
 
     elif args.language == "de":
         from nemo_text_processing.inverse_text_normalization.de.taggers.tokenize_and_classify import (
@@ -190,9 +171,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.de.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.de.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.de.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "ru":
         from nemo_text_processing.inverse_text_normalization.ru.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -210,9 +189,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.es.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.es.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.es.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "pt":
         from nemo_text_processing.inverse_text_normalization.pt.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -230,9 +207,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.fr.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.fr.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.fr.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "hi":
         from nemo_text_processing.inverse_text_normalization.hi.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -246,16 +221,12 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.hi.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.hi.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.hi.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "hu":
         from nemo_text_processing.text_normalization.hu.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.hu.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.hu.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "sv":
         from nemo_text_processing.inverse_text_normalization.sv.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -266,9 +237,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.sv.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.sv.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.sv.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "vi":
         from nemo_text_processing.inverse_text_normalization.vi.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -289,9 +258,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.zh.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.zh.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.zh.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "ar":
         from nemo_text_processing.inverse_text_normalization.ar.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -306,9 +273,7 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.it.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.it.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.it.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "es_en":
         from nemo_text_processing.inverse_text_normalization.es_en.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
@@ -346,19 +311,13 @@ if __name__ == "__main__":
         from nemo_text_processing.text_normalization.ja.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.ja.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
+        from nemo_text_processing.text_normalization.ja.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
     elif args.language == "rw":
         from nemo_text_processing.text_normalization.rw.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.rw.verbalizers.verbalize import (
-            VerbalizeFst as TNVerbalizeFst,
-        )
-    output_dir = os.path.join(
-        args.output_dir, f"{args.language}_{args.grammars}_{args.input_case}"
-    )
+        from nemo_text_processing.text_normalization.rw.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
+    output_dir = os.path.join(args.output_dir, f"{args.language}_{args.grammars}_{args.input_case}")
     export_grammars(
         output_dir=output_dir,
         grammars=locals()[args.grammars](

--- a/tools/text_processing_deployment/pynini_export.py
+++ b/tools/text_processing_deployment/pynini_export.py
@@ -21,7 +21,7 @@ from argparse import ArgumentParser
 
 import pynini
 
-from nemo_text_processing.text_normalization.rw.graph_utils import generator_main
+from nemo_text_processing.text_normalization.en.graph_utils import generator_main
 
 # This script exports compiled grammars inside nemo_text_processing into OpenFst finite state archive files
 # tokenize_and_classify.far and verbalize.far for production purposes
@@ -29,24 +29,24 @@ from nemo_text_processing.text_normalization.rw.graph_utils import generator_mai
 
 def itn_grammars(**kwargs):
     d = {}
-    d['classify'] = {
-        'TOKENIZE_AND_CLASSIFY': ITNClassifyFst(
+    d["classify"] = {
+        "TOKENIZE_AND_CLASSIFY": ITNClassifyFst(
             cache_dir=kwargs["cache_dir"],
             overwrite_cache=kwargs["overwrite_cache"],
             whitelist=kwargs["whitelist"],
             input_case=kwargs["input_case"],
         ).fst
     }
-    d['verbalize'] = {'ALL': ITNVerbalizeFst().fst, 'REDUP': pynini.accep("REDUP")}
+    d["verbalize"] = {"ALL": ITNVerbalizeFst().fst, "REDUP": pynini.accep("REDUP")}
     if ITNPostProcessingFst is not None:
-        d['post_process'] = {'POSTPROCESSOR': ITNPostProcessingFst().fst}
+        d["post_process"] = {"POSTPROCESSOR": ITNPostProcessingFst().fst}
     return d
 
 
 def tn_grammars(**kwargs):
     d = {}
-    d['classify'] = {
-        'TOKENIZE_AND_CLASSIFY': TNClassifyFst(
+    d["classify"] = {
+        "TOKENIZE_AND_CLASSIFY": TNClassifyFst(
             input_case=kwargs["input_case"],
             deterministic=True,
             cache_dir=kwargs["cache_dir"],
@@ -54,9 +54,12 @@ def tn_grammars(**kwargs):
             whitelist=kwargs["whitelist"],
         ).fst
     }
-    d['verbalize'] = {'ALL': TNVerbalizeFst(deterministic=True).fst, 'REDUP': pynini.accep("REDUP")}
+    d["verbalize"] = {
+        "ALL": TNVerbalizeFst(deterministic=True).fst,
+        "REDUP": pynini.accep("REDUP"),
+    }
     if TNPostProcessingFst is not None:
-        d['post_process'] = {'POSTPROCESSOR': TNPostProcessingFst().fst}
+        d["post_process"] = {"POSTPROCESSOR": TNPostProcessingFst().fst}
     return d
 
 
@@ -83,7 +86,9 @@ def export_grammars(output_dir, grammars):
 
 def parse_args():
     parser = ArgumentParser()
-    parser.add_argument("--output_dir", help="output directory for grammars", required=True, type=str)
+    parser.add_argument(
+        "--output_dir", help="output directory for grammars", required=True, type=str
+    )
     parser.add_argument(
         "--language",
         help="language",
@@ -93,28 +98,36 @@ def parse_args():
             "es",
             "pt",
             "ru",
-            'fr',
-            'hu',
-            'sv',
-            'vi',
-            'zh',
-            'ar',
-            'it',
-            'es_en',
-            'hi',
-            'hy',
-            'mr',
-            'ja',
-            'rw',
+            "fr",
+            "hu",
+            "sv",
+            "vi",
+            "zh",
+            "ar",
+            "it",
+            "es_en",
+            "hi",
+            "hy",
+            "mr",
+            "ja",
+            "rw",
         ],
         type=str,
-        default='en',
+        default="en",
     )
     parser.add_argument(
-        "--grammars", help="grammars to be exported", choices=["tn_grammars", "itn_grammars"], type=str, required=True
+        "--grammars",
+        help="grammars to be exported",
+        choices=["tn_grammars", "itn_grammars"],
+        type=str,
+        required=True,
     )
     parser.add_argument(
-        "--input_case", help="input capitalization", choices=["lower_cased", "cased"], default="cased", type=str
+        "--input_case",
+        help="input capitalization",
+        choices=["lower_cased", "cased"],
+        default="cased",
+        type=str,
     )
     parser.add_argument(
         "--whitelist",
@@ -124,7 +137,11 @@ def parse_args():
         default=None,
         type=lambda x: None if x == "None" else x,
     )
-    parser.add_argument("--overwrite_cache", help="set to True to re-create .far grammar files", action="store_true")
+    parser.add_argument(
+        "--overwrite_cache",
+        help="set to True to re-create .far grammar files",
+        action="store_true",
+    )
     parser.add_argument(
         "--cache_dir",
         help="path to a dir with .far grammar file. Set to None to avoid using cache",
@@ -134,14 +151,19 @@ def parse_args():
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
 
-    if args.language in ['pt', 'ru', 'vi', 'es_en', 'mr'] and args.grammars == 'tn_grammars':
-        raise ValueError('Only ITN grammars could be deployed in Sparrowhawk for the selected languages.')
+    if (
+        args.language in ["pt", "ru", "vi", "es_en", "mr"]
+        and args.grammars == "tn_grammars"
+    ):
+        raise ValueError(
+            "Only ITN grammars could be deployed in Sparrowhawk for the selected languages."
+        )
     TNPostProcessingFst = None
     ITNPostProcessingFst = None
-    if args.language == 'en':
+    if args.language == "en":
         from nemo_text_processing.inverse_text_normalization.en.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -154,9 +176,11 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.en.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.en.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
+        from nemo_text_processing.text_normalization.en.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
 
-    elif args.language == 'de':
+    elif args.language == "de":
         from nemo_text_processing.inverse_text_normalization.de.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -166,15 +190,17 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.de.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.de.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'ru':
+        from nemo_text_processing.text_normalization.de.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "ru":
         from nemo_text_processing.inverse_text_normalization.ru.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
         from nemo_text_processing.inverse_text_normalization.ru.verbalizers.verbalize import (
             VerbalizeFst as ITNVerbalizeFst,
         )
-    elif args.language == 'es':
+    elif args.language == "es":
         from nemo_text_processing.inverse_text_normalization.es.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -184,15 +210,17 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.es.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.es.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'pt':
+        from nemo_text_processing.text_normalization.es.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "pt":
         from nemo_text_processing.inverse_text_normalization.pt.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
         from nemo_text_processing.inverse_text_normalization.pt.verbalizers.verbalize import (
             VerbalizeFst as ITNVerbalizeFst,
         )
-    elif args.language == 'fr':
+    elif args.language == "fr":
         from nemo_text_processing.inverse_text_normalization.fr.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -202,8 +230,10 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.fr.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.fr.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'hi':
+        from nemo_text_processing.text_normalization.fr.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "hi":
         from nemo_text_processing.inverse_text_normalization.hi.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -216,13 +246,17 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.hi.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.hi.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'hu':
+        from nemo_text_processing.text_normalization.hi.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "hu":
         from nemo_text_processing.text_normalization.hu.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.hu.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'sv':
+        from nemo_text_processing.text_normalization.hu.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "sv":
         from nemo_text_processing.inverse_text_normalization.sv.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -232,15 +266,17 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.sv.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.sv.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'vi':
+        from nemo_text_processing.text_normalization.sv.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "vi":
         from nemo_text_processing.inverse_text_normalization.vi.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
         from nemo_text_processing.inverse_text_normalization.vi.verbalizers.verbalize import (
             VerbalizeFst as ITNVerbalizeFst,
         )
-    elif args.language == 'zh':
+    elif args.language == "zh":
         from nemo_text_processing.inverse_text_normalization.zh.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -253,8 +289,10 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.zh.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.zh.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'ar':
+        from nemo_text_processing.text_normalization.zh.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "ar":
         from nemo_text_processing.inverse_text_normalization.ar.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -264,33 +302,35 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.ar.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-    elif args.language == 'it':
+    elif args.language == "it":
         from nemo_text_processing.text_normalization.it.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.it.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'es_en':
+        from nemo_text_processing.text_normalization.it.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "es_en":
         from nemo_text_processing.inverse_text_normalization.es_en.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
         from nemo_text_processing.inverse_text_normalization.es_en.verbalizers.verbalize import (
             VerbalizeFst as ITNVerbalizeFst,
         )
-    elif args.language == 'mr':
+    elif args.language == "mr":
         from nemo_text_processing.inverse_text_normalization.mr.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
         from nemo_text_processing.inverse_text_normalization.mr.verbalizers.verbalize import (
             VerbalizeFst as ITNVerbalizeFst,
         )
-    elif args.language == 'hy':
+    elif args.language == "hy":
         from nemo_text_processing.inverse_text_normalization.hy.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
         from nemo_text_processing.inverse_text_normalization.hy.verbalizers.verbalize import (
             VerbalizeFst as ITNVerbalizeFst,
         )
-    elif args.language == 'ja':
+    elif args.language == "ja":
         from nemo_text_processing.inverse_text_normalization.ja.taggers.tokenize_and_classify import (
             ClassifyFst as ITNClassifyFst,
         )
@@ -306,13 +346,19 @@ if __name__ == '__main__':
         from nemo_text_processing.text_normalization.ja.verbalizers.post_processing import (
             PostProcessingFst as TNPostProcessingFst,
         )
-        from nemo_text_processing.text_normalization.ja.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    elif args.language == 'rw':
+        from nemo_text_processing.text_normalization.ja.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    elif args.language == "rw":
         from nemo_text_processing.text_normalization.rw.taggers.tokenize_and_classify import (
             ClassifyFst as TNClassifyFst,
         )
-        from nemo_text_processing.text_normalization.rw.verbalizers.verbalize import VerbalizeFst as TNVerbalizeFst
-    output_dir = os.path.join(args.output_dir, f"{args.language}_{args.grammars}_{args.input_case}")
+        from nemo_text_processing.text_normalization.rw.verbalizers.verbalize import (
+            VerbalizeFst as TNVerbalizeFst,
+        )
+    output_dir = os.path.join(
+        args.output_dir, f"{args.language}_{args.grammars}_{args.input_case}"
+    )
     export_grammars(
         output_dir=output_dir,
         grammars=locals()[args.grammars](


### PR DESCRIPTION
# What does this PR do ?

Points the `graph_utils` import back to English from Kinyarwanda.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [x] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [x] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [x] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [x] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [x] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [x] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [x] Remove import guards (`try import: ... except: ...`) if not already done.
- [x] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [x] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
