### PR TITLE
bugfix in fst_alignment.py, fix get_word_segments function

### DIFF
--- a/nemo_text_processing/fst_alignment/alignment.py
+++ b/nemo_text_processing/fst_alignment/alignment.py
@@ -115,12 +115,11 @@ def get_word_segments(text: str) -> List[List[int]]:
             cur_span = []
         elif ch != ' ' and len(cur_span) == 0:
             cur_span.append(idx)
-    
+
     if len(cur_span) > 0:
         cur_span.append(len(text))
         spans.append(tuple(cur_span))
     return spans
-
 
 
 def create_symbol_table() -> pynini.SymbolTable:

--- a/nemo_text_processing/fst_alignment/alignment.py
+++ b/nemo_text_processing/fst_alignment/alignment.py
@@ -107,22 +107,20 @@ def get_word_segments(text: str) -> List[List[int]]:
     """
     Returns word segments from given text based on white space in form of list of index spans.
     """
-    spans = []
-    cur_span = [0]
+    spans, cur_span = [], []
     for idx, ch in enumerate(text):
-        if len(cur_span) == 0 and ch != " ":
+        if ch == ' ' and len(cur_span) == 1:
             cur_span.append(idx)
-        elif ch == " ":
-            cur_span.append(idx)
-            assert len(cur_span) == 2
-            spans.append(cur_span)
+            spans.append(tuple(cur_span))
             cur_span = []
-        elif idx == len(text) - 1:
-            idx += 1
+        elif ch != ' ' and len(cur_span) == 0:
             cur_span.append(idx)
-            assert len(cur_span) == 2
-            spans.append(cur_span)
+    
+    if len(cur_span) > 0:
+        cur_span.append(len(text))
+        spans.append(tuple(cur_span))
     return spans
+
 
 
 def create_symbol_table() -> pynini.SymbolTable:

--- a/tests/nemo_text_processing/fst_alignment/__init__.py
+++ b/tests/nemo_text_processing/fst_alignment/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/nemo_text_processing/fst_alignment/test_fst_alignment_utils.py
+++ b/tests/nemo_text_processing/fst_alignment/test_fst_alignment_utils.py
@@ -18,7 +18,6 @@ from nemo_text_processing.fst_alignment.alignment import get_word_segments
 
 
 class TestFSTAlignmentUtils:
-
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_get_word_segments(self):
@@ -30,10 +29,8 @@ class TestFSTAlignmentUtils:
         words = ["a", "hello", "world", "b", "ccc", "d", "e"]
         for text in [text1, text2, text3, text4, text5]:
             segments = get_word_segments(text)
-            assert ' '.join(text[s:e] for s,e in segments) == ' '.join(words)
-        
+            assert ' '.join(text[s:e] for s, e in segments) == ' '.join(words)
+
         empty_text = ""
         segments = get_word_segments(empty_text)
         assert segments == []
-
-

--- a/tests/nemo_text_processing/fst_alignment/test_fst_alignment_utils.py
+++ b/tests/nemo_text_processing/fst_alignment/test_fst_alignment_utils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_text_processing.fst_alignment.alignment import get_word_segments
+
+
+class TestFSTAlignmentUtils:
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_get_word_segments(self):
+        text1 = "a hello world    b ccc d   e"
+        text2 = " a hello world    b ccc d   e"
+        text3 = "a hello world    b ccc d   e "
+        text4 = " a hello world    b ccc d   e "
+        text5 = "  a hello world    b ccc d   e  "
+        words = ["a", "hello", "world", "b", "ccc", "d", "e"]
+        for text in [text1, text2, text3, text4, text5]:
+            segments = get_word_segments(text)
+            assert ' '.join(text[s:e] for s,e in segments) == ' '.join(words)
+        
+        empty_text = ""
+        segments = get_word_segments(empty_text)
+        assert segments == []
+
+


### PR DESCRIPTION
# What does this PR do ?

The function `get_word_segments` had two issues ([nv_bug_4989479]()):

- It didn’t return the correct number of spans in the output.
- It crashed when the text contained double spaces.

This PR includes a fix and tests for the `get_word_segments` function.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Have you signed your commits? Use ``git commit -s`` to sign.
- [X] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [X] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [X] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [X] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [X] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [X] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [X] Remove import guards (`try import: ... except: ...`) if not already done.
- [X] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [X] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
