### PR TITLE
Add French date class, initial implementation

### DIFF
--- a/nemo_text_processing/text_normalization/fr/data/dates/__init__.py
+++ b/nemo_text_processing/text_normalization/fr/data/dates/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_text_processing/text_normalization/fr/data/dates/eras.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/dates/eras.tsv
@@ -1,0 +1,8 @@
+20s	twenties
+30s thirties
+40s	forties
+50s	fifties
+60s	sixties 
+70s	seventies
+80s	eighties
+90s	nineties

--- a/nemo_text_processing/text_normalization/fr/data/dates/months.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/dates/months.tsv
@@ -1,0 +1,12 @@
+1	janvier
+2	février 
+3	mars
+4	avril
+5	mai 
+6	juin
+7	juillet
+8	août 
+9	septembre
+10	octobre
+11	novembre 
+12	décembre

--- a/nemo_text_processing/text_normalization/fr/taggers/date.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/date.py
@@ -1,20 +1,23 @@
 import pynini
 from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.en.graph_utils import NEMO_DIGIT, GraphFst
 from nemo_text_processing.text_normalization.fr.utils import get_abs_path
 
-from nemo_text_processing.text_normalization.en.graph_utils import GraphFst, NEMO_DIGIT
-
-
-# TODO: add articles? 'le...' 
+# TODO: add articles? 'le...'
 
 month_numbers = pynini.string_file(get_abs_path("data/dates/months.tsv"))
 eras = pynini.string_file(get_abs_path("data/dates/eras.tsv"))
-delete_leading_zero = (pynutil.delete("0") | (NEMO_DIGIT - "0")) + NEMO_DIGIT #reminder, NEMO_DIGIT = filter on digits
+delete_leading_zero = (
+    pynutil.delete("0") | (NEMO_DIGIT - "0")
+) + NEMO_DIGIT  # reminder, NEMO_DIGIT = filter on digits
+
 
 class DateFst(GraphFst):
     ''' Finite state transducer for classyfing dates, e.g.:
         '02.03.2003' -> date {day: 'deux' month: 'mai' year: 'deux mille trois' preserve order: true} 
     '''
+
     def __init__(self, cardinal: GraphFst, deterministic: bool = True):
         super().__init__(name="dates", kind="classify")
 
@@ -23,10 +26,10 @@ class DateFst(GraphFst):
         # 'le' -> 'le', 'les' -> 'les'
         le_determiner = pynini.accep("le ") | pynini.accep("les ")
         self.optional_le = pynini.closure(le_determiner, 0, 1)
-        
-        # '01' -> 'un' 
+
+        # '01' -> 'un'
         optional_leading_zero = delete_leading_zero | NEMO_DIGIT
-        valid_day_number = pynini.union(*[str(x) for x in range(1,32)]) 
+        valid_day_number = pynini.union(*[str(x) for x in range(1, 32)])
         premier = pynini.string_map([("1", "premier")])
         day_number_to_word = premier | cardinal_graph
 
@@ -59,7 +62,7 @@ class DateFst(GraphFst):
             )
 
         # Accepts "janvier", "février", etc
-        month_name_graph = pynutil.insert("month: \"") +  month_numbers.project("output") + pynutil.insert("\"")
+        month_name_graph = pynutil.insert("month: \"") + month_numbers.project("output") + pynutil.insert("\"")
 
         self.fst |= (
             pynutil.insert("date { ")
@@ -73,9 +76,8 @@ class DateFst(GraphFst):
         # Accepts "70s", "80s", etc
         self.fst |= pynutil.insert("date { year: \"") + eras + pynutil.insert("\" preserve_order: true }")
 
-
         # Accepts date ranges, "17-18-19 juin"  -> date { day: "17" day: "18": day: "19"}
-        for separator in ["-", "/"]: 
+        for separator in ["-", "/"]:
             day_range_graph = (
                 pynutil.insert("day: \"")
                 + pynini.closure(digit_to_day + pynutil.delete(separator) + pynutil.insert(" "), 1)
@@ -95,7 +97,6 @@ class DateFst(GraphFst):
         self.fst = self.fst.optimize()
 
 
-
 def apply_fst(text, fst):
     try:
         output = pynini.shortestpath(text @ fst).string()
@@ -103,8 +104,10 @@ def apply_fst(text, fst):
     except pynini.FstOpError:
         print(f"Error: No valid output with given input: '{text}'")
 
+
 if __name__ == "__main__":
     from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
+
     fst = DateFst(CardinalFst())
 
     print('DETERMINER')
@@ -132,7 +135,7 @@ if __name__ == "__main__":
     apply_fst("02/03/2003", fst.fst)
     apply_fst("02-03-2003", fst.fst)
     apply_fst("le 02.03.2003", fst.fst)
-    
+
     apply_fst("02.03", fst.fst)
     apply_fst("17 janvier", fst.fst)
     apply_fst("10 mars 2023", fst.fst)
@@ -142,4 +145,6 @@ if __name__ == "__main__":
     apply_fst("80s", fst.fst)
 
     print("\nDATE RANGES")
-    apply_fst("les 17/18/19 juin", fst.fst) # returns: date { day: "les dix-sept" day: "dix-huit" day: "dix-neuf" month: "juin" preserve_order: true }
+    apply_fst(
+        "les 17/18/19 juin", fst.fst
+    )  # returns: date { day: "les dix-sept" day: "dix-huit" day: "dix-neuf" month: "juin" preserve_order: true }

--- a/nemo_text_processing/text_normalization/fr/taggers/date.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/date.py
@@ -71,7 +71,7 @@ class DateFst(GraphFst):
         )
 
         # Accepts "70s", "80s", etc
-        self.fst |= pynutil.insert("date { decade: \"") + eras + pynutil.insert("\" preserve_order: true }")
+        self.fst |= pynutil.insert("date { year: \"") + eras + pynutil.insert("\" preserve_order: true }")
 
 
         # Accepts date ranges, "17-18-19 juin"  -> date { day: "17" day: "18": day: "19"}

--- a/nemo_text_processing/text_normalization/fr/taggers/date.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/date.py
@@ -1,0 +1,145 @@
+import pynini
+from pynini.lib import pynutil
+from nemo_text_processing.text_normalization.fr.utils import get_abs_path
+
+from nemo_text_processing.text_normalization.en.graph_utils import GraphFst, NEMO_DIGIT
+
+
+# TODO: add articles? 'le...' 
+
+month_numbers = pynini.string_file(get_abs_path("data/dates/months.tsv"))
+eras = pynini.string_file(get_abs_path("data/dates/eras.tsv"))
+delete_leading_zero = (pynutil.delete("0") | (NEMO_DIGIT - "0")) + NEMO_DIGIT #reminder, NEMO_DIGIT = filter on digits
+
+class DateFst(GraphFst):
+    ''' Finite state transducer for classyfing dates, e.g.:
+        '02.03.2003' -> date {day: 'deux' month: 'mai' year: 'deux mille trois' preserve order: true} 
+    '''
+    def __init__(self, cardinal: GraphFst, deterministic: bool = True):
+        super().__init__(name="dates", kind="classify")
+
+        cardinal_graph = cardinal.all_nums_no_tokens
+
+        # 'le' -> 'le', 'les' -> 'les'
+        le_determiner = pynini.accep("le ") | pynini.accep("les ")
+        self.optional_le = pynini.closure(le_determiner, 0, 1)
+        
+        # '01' -> 'un' 
+        optional_leading_zero = delete_leading_zero | NEMO_DIGIT
+        valid_day_number = pynini.union(*[str(x) for x in range(1,32)]) 
+        premier = pynini.string_map([("1", "premier")])
+        day_number_to_word = premier | cardinal_graph
+
+        digit_to_day = self.optional_le + optional_leading_zero @ valid_day_number @ day_number_to_word
+        self.day_graph = pynutil.insert("day: \"") + digit_to_day + pynutil.insert("\"")
+
+        # '03' -> 'mars'
+        normalize_month_number = optional_leading_zero @ pynini.union(*[str(x) for x in range(1, 13)])
+        number_to_month = month_numbers.optimize()
+        month_graph = normalize_month_number @ number_to_month
+        self.month_graph = pynutil.insert("month: \"") + month_graph + pynutil.insert("\"")
+
+        # 2025 -> deux mille vingt cinq
+        accept_year_digits = (NEMO_DIGIT - "0") + pynini.closure(NEMO_DIGIT, 1, 3)
+        digits_to_year = accept_year_digits @ cardinal_graph
+        self.year_graph = pynutil.insert("year: \"") + digits_to_year + pynutil.insert("\"")
+
+        # Putting it all together
+        self.fst = pynini.accep("")
+
+        for separator in ["/", ".", "-"]:
+            self.fst |= (
+                pynutil.insert("date { ")
+                + self.day_graph
+                + pynutil.delete(separator)
+                + pynutil.insert(" ")
+                + self.month_graph
+                + pynini.closure(pynutil.delete(separator) + pynutil.insert(" ") + self.year_graph, 0, 1)
+                + pynutil.insert(" preserve_order: true }")
+            )
+
+        # Accepts "janvier", "février", etc
+        month_name_graph = pynutil.insert("month: \"") +  month_numbers.project("output") + pynutil.insert("\"")
+
+        self.fst |= (
+            pynutil.insert("date { ")
+            + self.day_graph
+            + pynini.accep(" ")
+            + month_name_graph
+            + pynini.closure(pynini.accep(" ") + self.year_graph, 0, 1)
+            + pynutil.insert(" preserve_order: true}")
+        )
+
+        # Accepts "70s", "80s", etc
+        self.fst |= pynutil.insert("date { decade: \"") + eras + pynutil.insert("\" preserve_order: true }")
+
+
+        # Accepts date ranges, "17-18-19 juin"  -> date { day: "17" day: "18": day: "19"}
+        for separator in ["-", "/"]: 
+            day_range_graph = (
+                pynutil.insert("day: \"")
+                + pynini.closure(digit_to_day + pynutil.delete(separator) + pynutil.insert(" "), 1)
+                + digit_to_day
+                + pynutil.insert("\"")
+            )
+
+            self.fst |= (
+                pynutil.insert("date { ")
+                + day_range_graph
+                + pynini.accep(" ")
+                + month_name_graph
+                + pynini.closure(pynini.accep(" ") + self.year_graph, 0, 1)
+                + pynutil.insert(" preserve_order: true }")
+            )
+
+        self.fst = self.fst.optimize()
+
+
+
+def apply_fst(text, fst):
+    try:
+        output = pynini.shortestpath(text @ fst).string()
+        print(f"'{text}' --> '{output}'")
+    except pynini.FstOpError:
+        print(f"Error: No valid output with given input: '{text}'")
+
+if __name__ == "__main__":
+    from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
+    fst = DateFst(CardinalFst())
+
+    print('DETERMINER')
+    apply_fst("le ", fst.optional_le)
+    apply_fst("", fst.optional_le)
+
+    print("\nDAY GRAPH")
+    apply_fst("01", fst.day_graph)
+    apply_fst("02", fst.day_graph)
+    apply_fst("3", fst.day_graph)
+    apply_fst("12", fst.day_graph)
+    apply_fst("le 01", fst.day_graph)
+    apply_fst("le 12", fst.day_graph)
+
+    print("\nMONTH GRAPH")
+    apply_fst("1", fst.month_graph)
+    apply_fst("3", fst.month_graph)
+    apply_fst("06", fst.month_graph)
+
+    print("\nYEAR")
+    apply_fst("2025", fst.year_graph)
+
+    print("\nDATE")
+    apply_fst("02.03.2003", fst.fst)
+    apply_fst("02/03/2003", fst.fst)
+    apply_fst("02-03-2003", fst.fst)
+    apply_fst("le 02.03.2003", fst.fst)
+    
+    apply_fst("02.03", fst.fst)
+    apply_fst("17 janvier", fst.fst)
+    apply_fst("10 mars 2023", fst.fst)
+    apply_fst("le 10 mars 2023", fst.fst)
+
+    print("\nERAS")
+    apply_fst("80s", fst.fst)
+
+    print("\nDATE RANGES")
+    apply_fst("les 17/18/19 juin", fst.fst) # returns: date { day: "les dix-sept" day: "dix-huit" day: "dix-neuf" month: "juin" preserve_order: true }

--- a/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
@@ -26,12 +26,12 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
 )
 from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
 from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
+from nemo_text_processing.text_normalization.fr.taggers.date import DateFst
 from nemo_text_processing.text_normalization.fr.taggers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.taggers.fraction import FractionFst
 from nemo_text_processing.text_normalization.fr.taggers.ordinal import OrdinalFst
 from nemo_text_processing.text_normalization.fr.taggers.whitelist import WhiteListFst
 from nemo_text_processing.text_normalization.fr.taggers.word import WordFst
-from nemo_text_processing.text_normalization.fr.taggers.date import DateFst
 from nemo_text_processing.utils.logging import logger
 
 
@@ -86,7 +86,7 @@ class ClassifyFst(GraphFst):
             self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
-            
+
             self.date = DateFst(self.cardinal, deterministic=deterministic)
             date_graph = self.date.fst
 

--- a/nemo_text_processing/text_normalization/fr/verbalizers/date.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/date.py
@@ -19,8 +19,9 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     NEMO_NOT_QUOTE,
     NEMO_SPACE,
     GraphFst,
-    delete_preserve_order
+    delete_preserve_order,
 )
+
 
 class DateFst(GraphFst):
     """
@@ -50,12 +51,14 @@ class DateFst(GraphFst):
         delete_tokens = self.delete_tokens(self.graph)
         self.fst = delete_tokens.optimize()
 
+
 def apply_fst(text, fst):
     try:
         output = pynini.shortestpath(text @ fst).string()
         print(f"'{text}' --> '{output}'")
     except pynini.FstOpError:
         print(f"Error: No valid output with given input: '{text}'")
+
 
 if __name__ == "__main__":
     fst = DateFst()

--- a/nemo_text_processing/text_normalization/fr/verbalizers/date.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/date.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pynini
+from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    NEMO_NOT_QUOTE,
+    NEMO_SPACE,
+    GraphFst,
+    delete_preserve_order
+)
+
+class DateFst(GraphFst):
+    """
+    Finite state transducer for verbalizing date, e.g.
+        date {day: "deux" month: "mars" year: "deux mille trois" preserve_order: true} -> deux mars deux mille trois
+
+    Args:
+        ordinal: OrdinalFst
+        deterministic: if True will provide a single transduction option,
+            for False multiple transduction are generated (used for audio-based normalization)
+    """
+
+    def __init__(self, deterministic: bool = True):
+        super().__init__(name="date", kind="verbalize", deterministic=deterministic)
+
+        day = pynutil.delete("day: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+        month = pynutil.delete("month: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+        year = pynutil.delete("year: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+        decade = pynutil.delete("decade: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+
+        graph_dmy = day + NEMO_SPACE + month + pynini.closure(NEMO_SPACE + year, 0, 1) + delete_preserve_order
+        graph_my = month + NEMO_SPACE + year + delete_preserve_order
+        graph_decade = decade + delete_preserve_order
+
+        self.graph = graph_dmy | graph_my | graph_decade
+
+        delete_tokens = self.delete_tokens(self.graph)
+        self.fst = delete_tokens.optimize()
+
+def apply_fst(text, fst):
+    try:
+        output = pynini.shortestpath(text @ fst).string()
+        print(f"'{text}' --> '{output}'")
+    except pynini.FstOpError:
+        print(f"Error: No valid output with given input: '{text}'")
+
+if __name__ == "__main__":
+    fst = DateFst()
+
+    # tagger output for "les 17/18/19 juin"
+    apply_fst('date { day: "les dix-sept dix-huit dix-neuf" month: "juin" preserve_order: true }', fst.fst)

--- a/nemo_text_processing/text_normalization/fr/verbalizers/date.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/date.py
@@ -39,7 +39,7 @@ class DateFst(GraphFst):
         day = pynutil.delete("day: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
         month = pynutil.delete("month: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
         year = pynutil.delete("year: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
-        decade = pynutil.delete("decade: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+        decade = pynutil.delete("year: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
 
         graph_dmy = day + NEMO_SPACE + month + pynini.closure(NEMO_SPACE + year, 0, 1) + delete_preserve_order
         graph_my = month + NEMO_SPACE + year + delete_preserve_order
@@ -60,5 +60,5 @@ def apply_fst(text, fst):
 if __name__ == "__main__":
     fst = DateFst()
 
-    # tagger output for "les 17/18/19 juin"
-    apply_fst('date { day: "les dix-sept dix-huit dix-neuf" month: "juin" preserve_order: true }', fst.fst)
+    # tagger output for "eighties"
+    apply_fst('date { year: "eighties" preserve_order: true }', fst.fst)

--- a/nemo_text_processing/text_normalization/fr/verbalizers/verbalize.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/verbalize.py
@@ -14,10 +14,10 @@
 from nemo_text_processing.text_normalization.en.graph_utils import GraphFst
 from nemo_text_processing.text_normalization.en.verbalizers.whitelist import WhiteListFst
 from nemo_text_processing.text_normalization.fr.verbalizers.cardinal import CardinalFst
+from nemo_text_processing.text_normalization.fr.verbalizers.date import DateFst
 from nemo_text_processing.text_normalization.fr.verbalizers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.verbalizers.fraction import FractionFst
 from nemo_text_processing.text_normalization.fr.verbalizers.ordinal import OrdinalFst
-from nemo_text_processing.text_normalization.fr.verbalizers.date import DateFst
 
 
 class VerbalizeFst(GraphFst):

--- a/nemo_text_processing/text_normalization/fr_tutorial/__init__.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_text_processing/text_normalization/fr_tutorial/data/__init__.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/data/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_text_processing/text_normalization/fr_tutorial/data/numbers/digits.tsv
+++ b/nemo_text_processing/text_normalization/fr_tutorial/data/numbers/digits.tsv
@@ -1,0 +1,11 @@
+zéro    0
+un      1
+une     1
+deux    2
+trois   3
+quatre  4
+cinq    5
+six     6
+sept    7
+huit    8
+neuf    9

--- a/nemo_text_processing/text_normalization/fr_tutorial/data/whitelist.tsv
+++ b/nemo_text_processing/text_normalization/fr_tutorial/data/whitelist.tsv
@@ -1,0 +1,13 @@
+Mᵐᵉ	madame
+Mᵐᵉˢ	mesdames
+Mˡˡᵉ	mademoiselle
+Mˡˡᵉˢ	mademoiselles
+Dʳ	docteur
+Dʳˢ	docteurs
+Dʳᵉ	docteure
+Dʳᵉˢ	docteures
+apr. J.-C.	après jésus-christ
+av. J.-C.	avant Jésus-Christ
+le hon.	l’honorable
+le très hon.	le très hononrable
+%	pour cent

--- a/nemo_text_processing/text_normalization/fr_tutorial/taggers/my_test_script.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/taggers/my_test_script.py
@@ -3,43 +3,43 @@ from pynini.lib import pynutil
 
 from nemo_text_processing.text_normalization.fr.utils import get_abs_path
 
+
 def apply_fst(text, fst):
-  """ Given a string input, returns the output string
+    """ Given a string input, returns the output string
   produced by traversing the path with lowest weight.
   If no valid path accepts input string, returns an
   error.
   """
-  try:
-     print(pynini.shortestpath(text @ fst).string())
-  except pynini.FstOpError:
-    print(f"Error: No valid output with given input: '{text}'")
+    try:
+        print(pynini.shortestpath(text @ fst).string())
+    except pynini.FstOpError:
+        print(f"Error: No valid output with given input: '{text}'")
 
-zero = pynini.string_map([("zéro","0")]) # French only pronounces zeroes as stand alone
-digits_map = pynini.string_map([ # pynini function that creates explicit input-output mappings for a WFST
-				("un","1"),
-				("une","1"),
-				("deux","2"),
-				("trois","3"),
-				("quatre","4"),
-				("cinq","5"),
-				("six","6"),
-				("sept","7"),
-				("huit","8"),
-				("neuf","9")
-])
+
+zero = pynini.string_map([("zéro", "0")])  # French only pronounces zeroes as stand alone
+digits_map = pynini.string_map(
+    [  # pynini function that creates explicit input-output mappings for a WFST
+        ("un", "1"),
+        ("une", "1"),
+        ("deux", "2"),
+        ("trois", "3"),
+        ("quatre", "4"),
+        ("cinq", "5"),
+        ("six", "6"),
+        ("sept", "7"),
+        ("huit", "8"),
+        ("neuf", "9"),
+    ]
+)
 
 digits = pynini.string_file("data/numbers/digits.tsv")
 
-teens = pynini.string_map([
-    ("onze", "11"),
-    ("douze", "12"), 
-    ("treize", "13"),
-    ("quatorze", "14"),
-    ("quinze", "16"), 
-])
+teens = pynini.string_map([("onze", "11"), ("douze", "12"), ("treize", "13"), ("quatorze", "14"), ("quinze", "16"),])
 
 tens = pynini.string_map([("dix", "1")])
-delete_hyphen = pynini.closure(pynutil.delete("-"), 0, 1) # Applies a closure from 0-1 of operation. Equivalent to regex /?/
+delete_hyphen = pynini.closure(
+    pynutil.delete("-"), 0, 1
+)  # Applies a closure from 0-1 of operation. Equivalent to regex /?/
 
 graph_tens = tens + delete_hyphen + digits
 graph_tens_and_teens = graph_tens | teens

--- a/nemo_text_processing/text_normalization/fr_tutorial/taggers/my_test_script.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/taggers/my_test_script.py
@@ -1,0 +1,49 @@
+import pynini
+from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.fr.utils import get_abs_path
+
+def apply_fst(text, fst):
+  """ Given a string input, returns the output string
+  produced by traversing the path with lowest weight.
+  If no valid path accepts input string, returns an
+  error.
+  """
+  try:
+     print(pynini.shortestpath(text @ fst).string())
+  except pynini.FstOpError:
+    print(f"Error: No valid output with given input: '{text}'")
+
+zero = pynini.string_map([("zéro","0")]) # French only pronounces zeroes as stand alone
+digits_map = pynini.string_map([ # pynini function that creates explicit input-output mappings for a WFST
+				("un","1"),
+				("une","1"),
+				("deux","2"),
+				("trois","3"),
+				("quatre","4"),
+				("cinq","5"),
+				("six","6"),
+				("sept","7"),
+				("huit","8"),
+				("neuf","9")
+])
+
+digits = pynini.string_file("data/numbers/digits.tsv")
+
+teens = pynini.string_map([
+    ("onze", "11"),
+    ("douze", "12"), 
+    ("treize", "13"),
+    ("quatorze", "14"),
+    ("quinze", "16"), 
+])
+
+tens = pynini.string_map([("dix", "1")])
+delete_hyphen = pynini.closure(pynutil.delete("-"), 0, 1) # Applies a closure from 0-1 of operation. Equivalent to regex /?/
+
+graph_tens = tens + delete_hyphen + digits
+graph_tens_and_teens = graph_tens | teens
+
+graph_digits = digits | pynutil.insert("0")
+
+apply_fst("un", graph_tens_and_teens)

--- a/nemo_text_processing/text_normalization/fr_tutorial/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/taggers/tokenize_and_classify.py
@@ -31,7 +31,6 @@ from nemo_text_processing.text_normalization.fr.taggers.fraction import Fraction
 from nemo_text_processing.text_normalization.fr.taggers.ordinal import OrdinalFst
 from nemo_text_processing.text_normalization.fr.taggers.whitelist import WhiteListFst
 from nemo_text_processing.text_normalization.fr.taggers.word import WordFst
-from nemo_text_processing.text_normalization.fr.taggers.date import DateFst
 from nemo_text_processing.utils.logging import logger
 
 
@@ -86,13 +85,9 @@ class ClassifyFst(GraphFst):
             self.whitelist = WhiteListFst(input_case=input_case, deterministic=deterministic, input_file=whitelist)
             whitelist_graph = self.whitelist.fst
             punct_graph = PunctuationFst(deterministic=deterministic).fst
-            
-            self.date = DateFst(self.cardinal, deterministic=deterministic)
-            date_graph = self.date.fst
 
             classify = (
                 pynutil.add_weight(whitelist_graph, 1.01)
-                | pynutil.add_weight(date_graph, 1.1)
                 | pynutil.add_weight(cardinal_graph, 1.1)
                 | pynutil.add_weight(fraction_graph, 1.09)
                 | pynutil.add_weight(ordinal_graph, 1.1)

--- a/nemo_text_processing/text_normalization/fr_tutorial/utils.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/utils.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import os
+
+
+def get_abs_path(rel_path):
+    """
+    Get absolute path
+
+    Args:
+        rel_path: relative path to this file
+
+    Returns absolute path
+    """
+    return os.path.dirname(os.path.abspath(__file__)) + '/' + rel_path
+
+
+def load_labels(abs_path):
+    """
+    loads relative path file as dictionary
+
+    Args:
+        abs_path: absolute path
+
+    Returns dictionary of mappings
+    """
+    label_tsv = open(abs_path)
+    labels = list(csv.reader(label_tsv, delimiter="\t"))
+    label_tsv.close()
+    return labels

--- a/nemo_text_processing/text_normalization/fr_tutorial/verbalizers/verbalize.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/verbalizers/verbalize.py
@@ -17,7 +17,6 @@ from nemo_text_processing.text_normalization.fr.verbalizers.cardinal import Card
 from nemo_text_processing.text_normalization.fr.verbalizers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.verbalizers.fraction import FractionFst
 from nemo_text_processing.text_normalization.fr.verbalizers.ordinal import OrdinalFst
-from nemo_text_processing.text_normalization.fr.verbalizers.date import DateFst
 
 
 class VerbalizeFst(GraphFst):
@@ -41,8 +40,6 @@ class VerbalizeFst(GraphFst):
         fraction = FractionFst(ordinal=ordinal, deterministic=deterministic)
         fraction_graph = fraction.fst
         whitelist_graph = WhiteListFst(deterministic=deterministic).fst
-        date = DateFst(deterministic=deterministic)
-        date_graph = date.fst
 
-        graph = cardinal_graph | decimal_graph | ordinal_graph | fraction_graph | whitelist_graph | date_graph
+        graph = cardinal_graph | decimal_graph | ordinal_graph | fraction_graph | whitelist_graph
         self.fst = graph

--- a/nemo_text_processing/text_normalization/fr_tutorial/verbalizers/verbalize_final.py
+++ b/nemo_text_processing/text_normalization/fr_tutorial/verbalizers/verbalize_final.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pynini
+from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    GraphFst,
+    delete_extra_space,
+    delete_space,
+    generator_main,
+)
+from nemo_text_processing.text_normalization.en.verbalizers.word import WordFst
+from nemo_text_processing.text_normalization.fr.verbalizers.verbalize import VerbalizeFst
+from nemo_text_processing.utils.logging import logger
+
+
+class VerbalizeFinalFst(GraphFst):
+    """
+    Finite state transducer that verbalizes an entire sentence
+    Args:
+        deterministic: if True will provide a single transduction option,
+            for False multiple options (used for audio-based normalization)
+        cache_dir: path to a dir with .far grammar file. Set to None to avoid using cache.
+        overwrite_cache: set to True to overwrite .far files
+    """
+
+    def __init__(self, deterministic: bool = True, cache_dir: str = None, overwrite_cache: bool = False):
+        super().__init__(name="verbalize_final", kind="verbalize", deterministic=deterministic)
+
+        far_file = None
+        if cache_dir is not None and cache_dir != "None":
+            os.makedirs(cache_dir, exist_ok=True)
+            far_file = os.path.join(cache_dir, f"fr_tn_{deterministic}_deterministic_verbalizer.far")
+        if not overwrite_cache and far_file and os.path.exists(far_file):
+            self.fst = pynini.Far(far_file, mode="r")["verbalize"]
+            logger.info(f'VerbalizeFinalFst graph was restored from {far_file}.')
+        else:
+
+            verbalize = VerbalizeFst(deterministic=deterministic).fst
+            word = WordFst(deterministic=deterministic).fst
+            types = verbalize | word
+            graph = (
+                pynutil.delete("tokens")
+                + delete_space
+                + pynutil.delete("{")
+                + delete_space
+                + types
+                + delete_space
+                + pynutil.delete("}")
+            )
+            graph = delete_space + pynini.closure(graph + delete_extra_space) + graph + delete_space
+
+            self.fst = graph.optimize()
+            if far_file:
+                generator_main(far_file, {"verbalize": self.fst})
+                logger.info(f"VerbalizeFinalFst grammars are saved to {far_file}.")

--- a/tests/nemo_text_processing/fr/data_text_normalization/test_cases_date.txt
+++ b/tests/nemo_text_processing/fr/data_text_normalization/test_cases_date.txt
@@ -1,0 +1,13 @@
+02.03.2003~deux mars deux mille trois
+02/03/2003~deux mars deux mille trois
+02-03-2003~deux mars deux mille trois
+le 02.03.2003~le deux mars deux mille trois
+17.06~dix-sept juin
+17 janvier~dix-sept janvier
+10 mars 2023~dix mars deux mille vingt-trois
+le 10 mars 2023~le dix mars deux mille vingt-trois
+les 80s~les eighties
+les 17/18 juin~les dix-sept dix-huit juin
+les 17/18/19 mars~les dix-sept dix-huit dix-neuf mars
+les 17-18-19 juin~les dix-sept dix-huit dix-neuf juin
+les 17-18-19 juin 2025~les dix-sept dix-huit dix-neuf juin deux mille vingt-cinq

--- a/tests/nemo_text_processing/fr/test_date.py
+++ b/tests/nemo_text_processing/fr/test_date.py
@@ -16,6 +16,7 @@ import pytest
 from parameterized import parameterized
 
 from nemo_text_processing.inverse_text_normalization.inverse_normalize import InverseNormalizer
+from nemo_text_processing.text_normalization.normalize import Normalizer
 
 from ..utils import CACHE_DIR, parse_test_case_file
 
@@ -28,4 +29,13 @@ class TestDate:
     @pytest.mark.unit
     def test_denorm(self, test_input, expected):
         pred = self.inverse_normalizer.inverse_normalize(test_input, verbose=False)
+        assert pred == expected
+
+    normalizer = Normalizer(input_case='cased', lang='fr', cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('fr/data_text_normalization/test_cases_date.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm(self, test_input, expected):
+        pred = self.normalizer.normalize(test_input, verbose=False)
         assert pred == expected

--- a/tests/nemo_text_processing/fr/test_sparrowhawk_normalization.sh
+++ b/tests/nemo_text_processing/fr/test_sparrowhawk_normalization.sh
@@ -52,7 +52,7 @@ testTNWord() {
   runtest $input
 }
 
-testTNWord() {
+testTNDate() {
   input=$PROJECT_DIR/fr/data_text_normalization/test_cases_date.txt
   runtest $input
 }

--- a/tests/nemo_text_processing/fr/test_sparrowhawk_normalization.sh
+++ b/tests/nemo_text_processing/fr/test_sparrowhawk_normalization.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 GRAMMARS_DIR=${1:-"/workspace/sparrowhawk/documentation/grammars"}
-PROJECT_DIR=${2:-"/workspace/tests/en"}
+PROJECT_DIR=${2:-"/workspace/tests"}
 
 runtest () {
   input=$1
@@ -49,6 +49,11 @@ testTNWhitelist() {
 
 testTNWord() {
   input=$PROJECT_DIR/fr/data_text_normalization/test_cases_word.txt
+  runtest $input
+}
+
+testTNWord() {
+  input=$PROJECT_DIR/fr/data_text_normalization/test_cases_date.txt
   runtest $input
 }
 


### PR DESCRIPTION
# What does this PR do ?

This PR adds processing for dates in French. For now just a few basic cases.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [ ] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [ ] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [x] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [ ] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [ ] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [x] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [x] Remove import guards (`try import: ... except: ...`) if not already done.
- [x] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [x] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
