### PR TITLE
Enforce UTF-8 on loading all locale-specific dictionary labels

### DIFF
--- a/nemo_text_processing/text_normalization/fr/utils.py
+++ b/nemo_text_processing/text_normalization/fr/utils.py
@@ -37,7 +37,6 @@ def load_labels(abs_path):
 
     Returns dictionary of mappings
     """
-    label_tsv = open(abs_path)
-    labels = list(csv.reader(label_tsv, delimiter="\t"))
-    label_tsv.close()
+    with open(abs_path, encoding="utf-8") as label_tsv:
+        labels = list(csv.reader(label_tsv, delimiter="\t"))
     return labels

--- a/nemo_text_processing/text_normalization/hi/utils.py
+++ b/nemo_text_processing/text_normalization/hi/utils.py
@@ -38,9 +38,8 @@ def load_labels(abs_path):
 
     Returns dictionary of mappings
     """
-    label_tsv = open(abs_path, encoding="utf-8")
-    labels = list(csv.reader(label_tsv, delimiter="\t"))
-    label_tsv.close()
+    with open(abs_path, encoding="utf-8") as label_tsv:
+        labels = list(csv.reader(label_tsv, delimiter="\t"))
     return labels
 
 

--- a/nemo_text_processing/text_normalization/hu/utils.py
+++ b/nemo_text_processing/text_normalization/hu/utils.py
@@ -38,9 +38,9 @@ def load_labels(abs_path):
 
     Returns dictionary of mappings
     """
-    with open(abs_path) as label_tsv:
+    with open(abs_path, encoding="utf-8") as label_tsv:
         labels = list(csv.reader(label_tsv, delimiter="\t"))
-        return labels
+    return labels
 
 
 def load_inflection(abs_path):
@@ -53,7 +53,7 @@ def load_inflection(abs_path):
     Returns dictionary of mappings of word endings to
     lists of case endings.
     """
-    with open(abs_path) as inflection_tsv:
+    with open(abs_path, encoding="utf-8") as inflection_tsv:
         items = list(csv.reader(inflection_tsv, delimiter="\t"))
         inflections = {k[0]: k[1].split(" ") for k in items}
         return inflections

--- a/nemo_text_processing/text_normalization/hy/utils.py
+++ b/nemo_text_processing/text_normalization/hy/utils.py
@@ -37,7 +37,6 @@ def load_labels(abs_path):
 
     Returns dictionary of mappings
     """
-    label_tsv = open(abs_path)
-    labels = list(csv.reader(label_tsv, delimiter="\t"))
-    label_tsv.close()
+    with open(abs_path, encoding="utf-8") as label_tsv:
+        labels = list(csv.reader(label_tsv, delimiter="\t"))
     return labels

--- a/nemo_text_processing/text_normalization/ja/utils.py
+++ b/nemo_text_processing/text_normalization/ja/utils.py
@@ -28,20 +28,6 @@ def get_abs_path(rel_path):
     return os.path.dirname(os.path.abspath(__file__)) + '/' + rel_path
 
 
-# def load_labels(abs_path):
-#     """
-#     loads relative path file as dictionary
-
-#     Args:
-#         abs_path: absolute path
-
-
-#     Returns dictionary of mappings
-#     """
-#     #label_tsv = open(abs_path, encoding="utf-8")
-#     label_tsv = open(abs_path, "r")
-#     labels = list(csv.reader(label_tsv, delimiter="\t"))
-#     return labels
 def load_labels(abs_path):
     """
     loads relative path file as dictionary

--- a/nemo_text_processing/text_normalization/normalize_with_audio.py
+++ b/nemo_text_processing/text_normalization/normalize_with_audio.py
@@ -511,7 +511,7 @@ if __name__ == "__main__":
         )
         start = perf_counter()
         if os.path.exists(args.text):
-            with open(args.text, 'r') as f:
+            with open(args.text, 'r', encoding='utf-8') as f:
                 args.text = f.read().strip()
 
         options = normalizer.normalize(

--- a/nemo_text_processing/text_normalization/sv/utils.py
+++ b/nemo_text_processing/text_normalization/sv/utils.py
@@ -39,4 +39,4 @@ def load_labels(abs_path):
     """
     with open(abs_path, encoding="utf-8") as label_tsv:
         labels = list(csv.reader(label_tsv, delimiter="\t"))
-        return labels
+    return labels

--- a/nemo_text_processing/text_normalization/zh/verbalizers/postprocessor.py
+++ b/nemo_text_processing/text_normalization/zh/verbalizers/postprocessor.py
@@ -69,7 +69,11 @@ class PostProcessor(GraphFst):
             en_charset = NEMO_DIGIT | NEMO_ALPHA | NEMO_PUNCT | NEMO_WHITE_SPACE
             charset = zh_charset | en_charset
 
-            with open(get_abs_path("data/char/oov_tags.tsv"), "r", encoding="utf-8",) as f:
+            with open(
+                get_abs_path("data/char/oov_tags.tsv"),
+                "r",
+                encoding="utf-8",
+            ) as f:
                 tags = f.readline().strip().split('\t')
                 assert len(tags) == 2
                 ltag, rtag = tags

--- a/nemo_text_processing/text_normalization/zh/verbalizers/postprocessor.py
+++ b/nemo_text_processing/text_normalization/zh/verbalizers/postprocessor.py
@@ -69,7 +69,7 @@ class PostProcessor(GraphFst):
             en_charset = NEMO_DIGIT | NEMO_ALPHA | NEMO_PUNCT | NEMO_WHITE_SPACE
             charset = zh_charset | en_charset
 
-            with open(get_abs_path("data/char/oov_tags.tsv"), "r") as f:
+            with open(get_abs_path("data/char/oov_tags.tsv"), "r", encoding="utf-8",) as f:
                 tags = f.readline().strip().split('\t')
                 assert len(tags) == 2
                 ltag, rtag = tags


### PR DESCRIPTION
  - Also added UTF-8 encoding on file reading elsewhere in the code
  - Related to https://github.com/NVIDIA/NeMo/pull/3520

# What does this PR do ?

Fixes the bug detailed here. 
https://github.com/NVIDIA/NeMo/issues/13310


# Before your PR is "Ready for review"
**Pre checks**:
- [X] Have you signed your commits? Use ``git commit -s`` to sign.
- [X] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [x] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [X] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [X] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [X] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [X] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [X] Remove import guards (`try import: ... except: ...`) if not already done.
- [X] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [X] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
