### PR TITLE
Add project_input support for english including tests

### DIFF
--- a/nemo_text_processing/inverse_text_normalization/en/taggers/cardinal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/cardinal.py
@@ -39,10 +39,11 @@ class CardinalFst(GraphFst):
 
     Args:
         input_case: accepting either "lower_cased" or "cased" input.
+        project: if True, adds input projection for mapping original text.
     """
 
-    def __init__(self, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="cardinal", kind="classify")
+    def __init__(self, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
+        super().__init__(name="cardinal", kind="classify", project_input=project_input)
         self.input_case = input_case
         graph_zero = pynini.string_file(get_abs_path("data/numbers/zero.tsv"))
         graph_digit = pynini.string_file(get_abs_path("data/numbers/digit.tsv"))

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
@@ -147,12 +147,7 @@ class DateFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(
-        self,
-        ordinal: GraphFst,
-        input_case: str,
-        project_input: bool = False
-    ):
+    def __init__(self, ordinal: GraphFst, input_case: str, project_input: bool = False):
         super().__init__(name="date", kind="classify", project_input=project_input)
 
         ordinal_graph = ordinal.graph

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
@@ -147,8 +147,13 @@ class DateFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, ordinal: GraphFst, input_case: str):
-        super().__init__(name="date", kind="classify")
+    def __init__(
+        self,
+        ordinal: GraphFst,
+        input_case: str,
+        project_input: bool = False
+    ):
+        super().__init__(name="date", kind="classify", project_input=project_input)
 
         ordinal_graph = ordinal.graph
         year_graph = _get_year_graph(input_case=input_case)

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/decimal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/decimal.py
@@ -83,8 +83,13 @@ class DecimalFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, cardinal: GraphFst, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="decimal", kind="classify")
+    def __init__(
+        self,
+        cardinal: GraphFst,
+        input_case: str = INPUT_LOWER_CASED,
+        project_input: bool = False
+    ):
+        super().__init__(name="decimal", kind="classify", project_input=project_input)
 
         cardinal_graph = cardinal.graph_no_exception
 

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/decimal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/decimal.py
@@ -83,12 +83,7 @@ class DecimalFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(
-        self,
-        cardinal: GraphFst,
-        input_case: str = INPUT_LOWER_CASED,
-        project_input: bool = False
-    ):
+    def __init__(self, cardinal: GraphFst, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
         super().__init__(name="decimal", kind="classify", project_input=project_input)
 
         cardinal_graph = cardinal.graph_no_exception

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/electronic.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/electronic.py
@@ -38,8 +38,8 @@ class ElectronicFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="electronic", kind="classify")
+    def __init__(self, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
+        super().__init__(name="electronic", kind="classify", project_input=project_input)
 
         delete_extra_space = pynutil.delete(" ")
 

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/fraction.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/fraction.py
@@ -24,6 +24,6 @@ class FractionFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="fraction", kind="classify")
+    def __init__(self, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
+        super().__init__(name="fraction", kind="classify", project_input=project_input)
         # integer_part # numerator # denominator

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/measure.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/measure.py
@@ -42,8 +42,14 @@ class MeasureFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, cardinal: GraphFst, decimal: GraphFst, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="measure", kind="classify")
+    def __init__(
+        self,
+        cardinal: GraphFst,
+        decimal: GraphFst,
+        input_case: str = INPUT_LOWER_CASED,
+        project_input: bool = False
+    ):
+        super().__init__(name="measure", kind="classify", project_input=project_input)
 
         cardinal_graph = cardinal.graph_no_exception
 

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/measure.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/measure.py
@@ -43,11 +43,7 @@ class MeasureFst(GraphFst):
     """
 
     def __init__(
-        self,
-        cardinal: GraphFst,
-        decimal: GraphFst,
-        input_case: str = INPUT_LOWER_CASED,
-        project_input: bool = False
+        self, cardinal: GraphFst, decimal: GraphFst, input_case: str = INPUT_LOWER_CASED, project_input: bool = False
     ):
         super().__init__(name="measure", kind="classify", project_input=project_input)
 

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/money.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/money.py
@@ -45,11 +45,7 @@ class MoneyFst(GraphFst):
     """
 
     def __init__(
-        self,
-        cardinal: GraphFst,
-        decimal: GraphFst,
-        input_case: str = INPUT_LOWER_CASED,
-        project_input: bool = False
+        self, cardinal: GraphFst, decimal: GraphFst, input_case: str = INPUT_LOWER_CASED, project_input: bool = False
     ):
         super().__init__(name="money", kind="classify", project_input=project_input)
         # quantity, integer_part, fractional_part, currency

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/money.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/money.py
@@ -44,8 +44,14 @@ class MoneyFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, cardinal: GraphFst, decimal: GraphFst, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="money", kind="classify")
+    def __init__(
+        self,
+        cardinal: GraphFst,
+        decimal: GraphFst,
+        input_case: str = INPUT_LOWER_CASED,
+        project_input: bool = False
+    ):
+        super().__init__(name="money", kind="classify", project_input=project_input)
         # quantity, integer_part, fractional_part, currency
 
         cardinal_graph = cardinal.graph_no_exception

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/ordinal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/ordinal.py
@@ -36,12 +36,7 @@ class OrdinalFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(
-        self,
-        cardinal: GraphFst,
-        input_case: str = INPUT_LOWER_CASED,
-        project_input: bool = False
-    ):
+    def __init__(self, cardinal: GraphFst, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
         super().__init__(name="ordinal", kind="classify", project_input=project_input)
 
         cardinal_graph = cardinal.graph_no_exception

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/ordinal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/ordinal.py
@@ -36,8 +36,13 @@ class OrdinalFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, cardinal: GraphFst, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="ordinal", kind="classify")
+    def __init__(
+        self,
+        cardinal: GraphFst,
+        input_case: str = INPUT_LOWER_CASED,
+        project_input: bool = False
+    ):
+        super().__init__(name="ordinal", kind="classify", project_input=project_input)
 
         cardinal_graph = cardinal.graph_no_exception
         graph_digit = pynini.string_file(get_abs_path("data/ordinals/digit.tsv"))

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/punctuation.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/punctuation.py
@@ -25,8 +25,8 @@ class PunctuationFst(GraphFst):
         e.g. a, -> tokens { name: "a" } tokens { name: "," }
     """
 
-    def __init__(self):
-        super().__init__(name="punctuation", kind="classify")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="punctuation", kind="classify", project_input=project_input)
 
         s = "!#$%&\'()*+,-./:;<=>?@^_`{|}~"
         punct = pynini.union(*s)

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/telephone.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/telephone.py
@@ -75,12 +75,7 @@ class TelephoneFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(
-        self,
-        cardinal: GraphFst,
-        input_case: str = INPUT_LOWER_CASED,
-        project_input: bool = False
-    ):
+    def __init__(self, cardinal: GraphFst, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
         super().__init__(name="telephone", kind="classify", project_input=project_input)
         # country code, number_part, extension
         digit_to_str = (

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/telephone.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/telephone.py
@@ -75,8 +75,13 @@ class TelephoneFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, cardinal: GraphFst, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="telephone", kind="classify")
+    def __init__(
+        self,
+        cardinal: GraphFst,
+        input_case: str = INPUT_LOWER_CASED,
+        project_input: bool = False
+    ):
+        super().__init__(name="telephone", kind="classify", project_input=project_input)
         # country code, number_part, extension
         digit_to_str = (
             pynini.invert(pynini.string_file(get_abs_path("data/numbers/digit.tsv")).optimize())

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/time.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/time.py
@@ -42,8 +42,8 @@ class TimeFst(GraphFst):
         e.g. half past two -> time { hours: "2" minutes: "30" }
     """
 
-    def __init__(self, input_case: str = INPUT_LOWER_CASED):
-        super().__init__(name="time", kind="classify")
+    def __init__(self, input_case: str = INPUT_LOWER_CASED, project_input: bool = False):
+        super().__init__(name="time", kind="classify", project_input=project_input)
         # hours, minutes, seconds, suffix, zone, style, speak_period
 
         suffix_graph = pynini.string_file(get_abs_path("data/time/time_suffix.tsv"))

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/tokenize_and_classify.py
@@ -35,8 +35,8 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     GraphFst,
     delete_extra_space,
     delete_space,
-    generator_main,
     generate_far_filename,
+    generator_main,
 )
 from nemo_text_processing.utils.logging import logger
 
@@ -75,7 +75,7 @@ class ClassifyFst(GraphFst):
                 operation="tokenize_and_classify",
                 project_input=project_input,
                 input_case=input_case,
-                whitelist_file=whitelist
+                whitelist_file=whitelist,
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -91,12 +91,18 @@ class ClassifyFst(GraphFst):
             decimal = DecimalFst(cardinal, input_case=input_case, project_input=project_input)
             decimal_graph = decimal.fst
 
-            measure_graph = MeasureFst(cardinal=cardinal, decimal=decimal, input_case=input_case, project_input=project_input).fst
+            measure_graph = MeasureFst(
+                cardinal=cardinal, decimal=decimal, input_case=input_case, project_input=project_input
+            ).fst
             date_graph = DateFst(ordinal=ordinal, input_case=input_case, project_input=project_input).fst
             word_graph = WordFst(project_input=project_input).fst
             time_graph = TimeFst(input_case=input_case, project_input=project_input).fst
-            money_graph = MoneyFst(cardinal=cardinal, decimal=decimal, input_case=input_case, project_input=project_input).fst
-            whitelist_graph = WhiteListFst(input_file=whitelist, input_case=input_case, project_input=project_input).fst
+            money_graph = MoneyFst(
+                cardinal=cardinal, decimal=decimal, input_case=input_case, project_input=project_input
+            ).fst
+            whitelist_graph = WhiteListFst(
+                input_file=whitelist, input_case=input_case, project_input=project_input
+            ).fst
             punct_graph = PunctuationFst(project_input=project_input).fst
             electronic_graph = ElectronicFst(input_case=input_case, project_input=project_input).fst
             telephone_graph = TelephoneFst(cardinal, input_case=input_case, project_input=project_input).fst

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/whitelist.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/whitelist.py
@@ -16,18 +16,15 @@
 
 import os
 
-import pynini
 from pynini.lib import pynutil
 
 from nemo_text_processing.inverse_text_normalization.en.utils import get_abs_path
 from nemo_text_processing.text_normalization.en.graph_utils import (
-    INPUT_CASED,
     INPUT_LOWER_CASED,
     GraphFst,
     convert_space,
     string_map_cased,
 )
-from nemo_text_processing.text_normalization.en.utils import load_labels
 
 
 class WhiteListFst(GraphFst):
@@ -43,8 +40,13 @@ class WhiteListFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(self, input_case: str = INPUT_LOWER_CASED, input_file: str = None):
-        super().__init__(name="whitelist", kind="classify")
+    def __init__(
+        self,
+        input_case: str = INPUT_LOWER_CASED,
+        input_file: str = None,
+        project_input: bool = False
+    ):
+        super().__init__(name="whitelist", kind="classify", project_input=project_input)
 
         if input_file is None:
             input_file = get_abs_path("data/whitelist.tsv")
@@ -54,4 +56,5 @@ class WhiteListFst(GraphFst):
 
         whitelist = string_map_cased(input_file, input_case)
         graph = pynutil.insert("name: \"") + convert_space(whitelist) + pynutil.insert("\"")
-        self.fst = graph.optimize()
+        final_graph = self.add_tokens(graph)
+        self.fst = final_graph.optimize()

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/whitelist.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/whitelist.py
@@ -40,12 +40,7 @@ class WhiteListFst(GraphFst):
         input_case: accepting either "lower_cased" or "cased" input.
     """
 
-    def __init__(
-        self,
-        input_case: str = INPUT_LOWER_CASED,
-        input_file: str = None,
-        project_input: bool = False
-    ):
+    def __init__(self, input_case: str = INPUT_LOWER_CASED, input_file: str = None, project_input: bool = False):
         super().__init__(name="whitelist", kind="classify", project_input=project_input)
 
         if input_file is None:

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/word.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/word.py
@@ -25,7 +25,7 @@ class WordFst(GraphFst):
         e.g. sleep -> tokens { name: "sleep" }
     """
 
-    def __init__(self):
-        super().__init__(name="word", kind="classify")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="word", kind="classify", project_input=project_input)
         word = pynutil.insert("name: \"") + pynini.closure(NEMO_NOT_SPACE, 1) + pynutil.insert("\"")
         self.fst = word.optimize()

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/cardinal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/cardinal.py
@@ -22,10 +22,13 @@ class CardinalFst(GraphFst):
     """
     Finite state transducer for verbalizing cardinal
         e.g. cardinal { integer: "23" negative: "-" } -> -23
+
+    Args:
+        project: if True, adds input projection for mapping original text.
     """
 
-    def __init__(self):
-        super().__init__(name="cardinal", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="cardinal", kind="verbalize", project_input=project_input)
         optional_sign = pynini.closure(
             pynutil.delete("negative:")
             + delete_space

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/date.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/date.py
@@ -30,8 +30,8 @@ class DateFst(GraphFst):
         date { day: "5" month: "january" year: "2012" preserve_order: true } -> 5 february 2012
     """
 
-    def __init__(self):
-        super().__init__(name="date", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="date", kind="verbalize", project_input=project_input)
         month = (
             pynutil.delete("month:")
             + delete_space

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/decimal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/decimal.py
@@ -24,8 +24,8 @@ class DecimalFst(GraphFst):
         decimal { negative: "true" integer_part: "12"  fractional_part: "5006" quantity: "billion" } -> -12.5006 billion
     """
 
-    def __init__(self):
-        super().__init__(name="decimal", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="decimal", kind="verbalize", project_input=project_input)
         optionl_sign = pynini.closure(pynini.cross("negative: \"true\"", "-") + delete_space, 0, 1)
         integer = (
             pynutil.delete("integer_part:")

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/electronic.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/electronic.py
@@ -24,8 +24,8 @@ class ElectronicFst(GraphFst):
         e.g. tokens { electronic { username: "cdf1" domain: "abc.edu" } } -> cdf1@abc.edu
     """
 
-    def __init__(self):
-        super().__init__(name="electronic", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="electronic", kind="verbalize", project_input=project_input)
         user_name = (
             pynutil.delete("username:")
             + delete_space

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/fraction.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/fraction.py
@@ -21,5 +21,5 @@ class FractionFst(GraphFst):
     Finite state transducer for verbalizing fraction,
     """
 
-    def __init__(self):
-        super().__init__(name="fraction", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="fraction", kind="verbalize", project_input=project_input)

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/measure.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/measure.py
@@ -29,8 +29,13 @@ class MeasureFst(GraphFst):
         cardinal: CardinalFst
     """
 
-    def __init__(self, decimal: GraphFst, cardinal: GraphFst):
-        super().__init__(name="measure", kind="verbalize")
+    def __init__(
+        self,
+        decimal: GraphFst,
+        cardinal: GraphFst,
+        project_input: bool = False
+    ):
+        super().__init__(name="measure", kind="verbalize", project_input=project_input)
         optional_sign = pynini.closure(pynini.cross("negative: \"true\"", "-"), 0, 1)
         unit = (
             pynutil.delete("units:")

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/measure.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/measure.py
@@ -29,12 +29,7 @@ class MeasureFst(GraphFst):
         cardinal: CardinalFst
     """
 
-    def __init__(
-        self,
-        decimal: GraphFst,
-        cardinal: GraphFst,
-        project_input: bool = False
-    ):
+    def __init__(self, decimal: GraphFst, cardinal: GraphFst, project_input: bool = False):
         super().__init__(name="measure", kind="verbalize", project_input=project_input)
         optional_sign = pynini.closure(pynini.cross("negative: \"true\"", "-"), 0, 1)
         unit = (

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/money.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/money.py
@@ -28,8 +28,8 @@ class MoneyFst(GraphFst):
         decimal: DecimalFst
     """
 
-    def __init__(self, decimal: GraphFst):
-        super().__init__(name="money", kind="verbalize")
+    def __init__(self, decimal: GraphFst, project_input: bool = False):
+        super().__init__(name="money", kind="verbalize", project_input=project_input)
         unit = (
             pynutil.delete("currency:")
             + delete_space

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/ordinal.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/ordinal.py
@@ -25,8 +25,8 @@ class OrdinalFst(GraphFst):
        ordinal { integer: "13" } -> 13th
     """
 
-    def __init__(self):
-        super().__init__(name="ordinal", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="ordinal", kind="verbalize", project_input=project_input)
         graph = (
             pynutil.delete("integer:")
             + delete_space

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/telephone.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/telephone.py
@@ -26,8 +26,8 @@ class TelephoneFst(GraphFst):
         -> 123-123-5678
     """
 
-    def __init__(self):
-        super().__init__(name="telephone", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="telephone", kind="verbalize", project_input=project_input)
 
         number_part = pynutil.delete("number_part: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
         optional_country_code = pynini.closure(

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/time.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/time.py
@@ -33,8 +33,8 @@ class TimeFst(GraphFst):
         time { hours: "2" suffix: "a.m." } -> 02:00 a.m.
     """
 
-    def __init__(self):
-        super().__init__(name="time", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="time", kind="verbalize", project_input=project_input)
         add_leading_zero_to_double_digit = (NEMO_DIGIT + NEMO_DIGIT) | (pynutil.insert("0") + NEMO_DIGIT)
         hour = (
             pynutil.delete("hours:")

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/verbalize.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/verbalize.py
@@ -33,20 +33,20 @@ class VerbalizeFst(GraphFst):
     More details to deployment at NeMo/tools/text_processing_deployment.
     """
 
-    def __init__(self):
+    def __init__(self, project_input: bool = False):
         super().__init__(name="verbalize", kind="verbalize")
-        cardinal = CardinalFst()
+        cardinal = CardinalFst(project_input=project_input)
         cardinal_graph = cardinal.fst
-        ordinal_graph = OrdinalFst().fst
-        decimal = DecimalFst()
+        ordinal_graph = OrdinalFst(project_input=project_input).fst
+        decimal = DecimalFst(project_input=project_input)
         decimal_graph = decimal.fst
-        measure_graph = MeasureFst(decimal=decimal, cardinal=cardinal).fst
-        money_graph = MoneyFst(decimal=decimal).fst
-        time_graph = TimeFst().fst
-        date_graph = DateFst().fst
-        whitelist_graph = WhiteListFst().fst
-        telephone_graph = TelephoneFst().fst
-        electronic_graph = ElectronicFst().fst
+        measure_graph = MeasureFst(decimal=decimal, cardinal=cardinal, project_input=project_input).fst
+        money_graph = MoneyFst(decimal=decimal, project_input=project_input).fst
+        time_graph = TimeFst(project_input=project_input).fst
+        date_graph = DateFst(project_input=project_input).fst
+        whitelist_graph = WhiteListFst(project_input=project_input).fst
+        telephone_graph = TelephoneFst(project_input=project_input).fst
+        electronic_graph = ElectronicFst(project_input=project_input).fst
         graph = (
             time_graph
             | date_graph

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/verbalize_final.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/verbalize_final.py
@@ -13,33 +13,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pynini
 from pynini.lib import pynutil
 
 from nemo_text_processing.inverse_text_normalization.en.verbalizers.verbalize import VerbalizeFst
 from nemo_text_processing.inverse_text_normalization.en.verbalizers.word import WordFst
-from nemo_text_processing.text_normalization.en.graph_utils import GraphFst, delete_extra_space, delete_space
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    GraphFst,
+    delete_extra_space,
+    delete_space,
+    generator_main,
+    generate_far_filename,
+)
+from nemo_text_processing.utils.logging import logger
 
 
 class VerbalizeFinalFst(GraphFst):
     """
     Finite state transducer that verbalizes an entire sentence, e.g.
     tokens { name: "its" } tokens { time { hours: "12" minutes: "30" } } tokens { name: "now" } -> its 12:30 now
+
+    Args:
+        project_input: if True, project input strings into output FST
+        cache_dir: path to a dir with .far grammar file. Set to None to avoid using cache.
+        overwrite_cache: set to True to overwrite .far files
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        project_input: bool = False,
+        cache_dir: str = None,
+        overwrite_cache: bool = False
+    ):
         super().__init__(name="verbalize_final", kind="verbalize")
-        verbalize = VerbalizeFst().fst
-        word = WordFst().fst
-        types = verbalize | word
-        graph = (
-            pynutil.delete("tokens")
-            + delete_space
-            + pynutil.delete("{")
-            + delete_space
-            + types
-            + delete_space
-            + pynutil.delete("}")
-        )
-        graph = delete_space + pynini.closure(graph + delete_extra_space) + graph + delete_space
-        self.fst = graph
+
+        far_file = None
+        if cache_dir is not None and cache_dir != "None":
+            os.makedirs(cache_dir, exist_ok=True)
+            far_file = generate_far_filename(
+                language="en",
+                mode="itn",
+                cache_dir=cache_dir,
+                operation="verbalize",
+                project_input=project_input
+            )
+        
+        if not overwrite_cache and far_file and os.path.exists(far_file):
+            self.fst = pynini.Far(far_file, mode="r")["verbalize"]
+            logger.info(f'VerbalizeFinalFst graph was restored from {far_file}.')
+        else:
+            verbalize = VerbalizeFst(project_input=project_input).fst
+            word = WordFst(project_input=project_input).fst
+            types = verbalize | word
+            graph = (
+                pynutil.delete("tokens")
+                + delete_space
+                + pynutil.delete("{")
+                + delete_space
+                + types
+                + delete_space
+                + pynutil.delete("}")
+            )
+            graph = delete_space + pynini.closure(graph + delete_extra_space) + graph + delete_space
+            
+            self.fst = graph.optimize()
+            if far_file:
+                generator_main(far_file, {"verbalize": self.fst})
+                logger.info(f"VerbalizeFinalFst grammars are saved to {far_file}.")

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/verbalize_final.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/verbalize_final.py
@@ -24,8 +24,8 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     GraphFst,
     delete_extra_space,
     delete_space,
-    generator_main,
     generate_far_filename,
+    generator_main,
 )
 from nemo_text_processing.utils.logging import logger
 
@@ -41,25 +41,16 @@ class VerbalizeFinalFst(GraphFst):
         overwrite_cache: set to True to overwrite .far files
     """
 
-    def __init__(
-        self,
-        project_input: bool = False,
-        cache_dir: str = None,
-        overwrite_cache: bool = False
-    ):
+    def __init__(self, project_input: bool = False, cache_dir: str = None, overwrite_cache: bool = False):
         super().__init__(name="verbalize_final", kind="verbalize")
 
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             far_file = generate_far_filename(
-                language="en",
-                mode="itn",
-                cache_dir=cache_dir,
-                operation="verbalize",
-                project_input=project_input
+                language="en", mode="itn", cache_dir=cache_dir, operation="verbalize", project_input=project_input
             )
-        
+
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["verbalize"]
             logger.info(f'VerbalizeFinalFst graph was restored from {far_file}.')
@@ -77,7 +68,7 @@ class VerbalizeFinalFst(GraphFst):
                 + pynutil.delete("}")
             )
             graph = delete_space + pynini.closure(graph + delete_extra_space) + graph + delete_space
-            
+
             self.fst = graph.optimize()
             if far_file:
                 generator_main(far_file, {"verbalize": self.fst})

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/whitelist.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/whitelist.py
@@ -35,6 +35,6 @@ class WhiteListFst(GraphFst):
             + pynini.closure(NEMO_CHAR - " ", 1)
             + pynutil.delete("\"")
         )
-        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)
         delete_tokens = self.delete_tokens(graph)
         self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/whitelist.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/whitelist.py
@@ -26,8 +26,8 @@ class WhiteListFst(GraphFst):
         e.g. tokens { name: "mrs." } -> mrs.
     """
 
-    def __init__(self):
-        super().__init__(name="whitelist", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="whitelist", kind="verbalize", project_input=project_input)
         graph = (
             pynutil.delete("name:")
             + delete_space
@@ -35,5 +35,6 @@ class WhiteListFst(GraphFst):
             + pynini.closure(NEMO_CHAR - " ", 1)
             + pynutil.delete("\"")
         )
-        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)
-        self.fst = graph.optimize()
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
+        delete_tokens = self.delete_tokens(graph)
+        self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/inverse_text_normalization/en/verbalizers/word.py
+++ b/nemo_text_processing/inverse_text_normalization/en/verbalizers/word.py
@@ -25,8 +25,8 @@ class WordFst(GraphFst):
         e.g. tokens { name: "sleep" } -> sleep
     """
 
-    def __init__(self):
-        super().__init__(name="word", kind="verbalize")
+    def __init__(self, project_input: bool = False):
+        super().__init__(name="word", kind="verbalize", project_input=project_input)
         chars = pynini.closure(NEMO_CHAR - " ", 1)
         char = pynutil.delete("name:") + delete_space + pynutil.delete("\"") + chars + pynutil.delete("\"")
         graph = char @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)

--- a/nemo_text_processing/inverse_text_normalization/inverse_normalize.py
+++ b/nemo_text_processing/inverse_text_normalization/inverse_normalize.py
@@ -44,6 +44,7 @@ class InverseNormalizer(Normalizer):
         self,
         input_case: str = INPUT_LOWER_CASED,
         lang: str = "en",
+        project_input: bool = False,
         whitelist: str = None,
         cache_dir: str = None,
         overwrite_cache: bool = False,
@@ -135,7 +136,18 @@ class InverseNormalizer(Normalizer):
         self.tagger = ClassifyFst(
             cache_dir=cache_dir, whitelist=whitelist, overwrite_cache=overwrite_cache, input_case=input_case
         )
-        self.verbalizer = VerbalizeFinalFst()
+
+        self.project_input = project_input
+        if self.project_input:
+            self.tagger_input_projector = ClassifyFst(
+                cache_dir=cache_dir,
+                project_input=True,
+                overwrite_cache=overwrite_cache,
+                whitelist=whitelist,
+                input_case=input_case,
+            )
+
+        self.verbalizer = VerbalizeFinalFst(cache_dir=cache_dir, project_input=project_input)
         self.parser = TokenParser()
         self.lang = lang
         self.max_number_of_permutations_per_split = max_number_of_permutations_per_split
@@ -193,6 +205,11 @@ def parse_args():
         default=None,
         type=str,
     )
+    parser.add_argument(
+        "--project_input",
+        help="Add this flag to project input text to ITN output. This is useful for getting a mapping between input and output text.",
+        action="store_true",
+    )
     parser.add_argument("--verbose", help="print info for debugging", action='store_true')
     parser.add_argument("--overwrite_cache", help="set to True to re-create .far grammar files", action="store_true")
     parser.add_argument(
@@ -214,6 +231,7 @@ if __name__ == "__main__":
         lang=args.language,
         cache_dir=args.cache_dir,
         overwrite_cache=args.overwrite_cache,
+        project_input=args.project_input,
         whitelist=whitelist,
     )
     print(f'Time to generate graph: {round(perf_counter() - start_time, 2)} sec')

--- a/nemo_text_processing/text_normalization/en/graph_utils.py
+++ b/nemo_text_processing/text_normalization/en/graph_utils.py
@@ -201,7 +201,7 @@ def generate_far_filename(
 ) -> str:
     """
     Generate FAR filename based on parameters.
-    
+
     Args:
         language: Language code (e.g., "en")
         mode: Either "tn" or "itn"
@@ -211,26 +211,26 @@ def generate_far_filename(
         project_input: If True, append "projecting" to filename
         input_case: Input case handling, append if INPUT_CASED
         whitelist_file: Whitelist filename to include
-        
+
     Returns:
         Complete path to FAR file
     """
     filename_parts = [language, mode]
-    
+
     if deterministic:
         filename_parts.append("deterministic")
-        
+
     if project_input:
         filename_parts.append("projecting")
-        
+
     if input_case == INPUT_CASED:
         filename_parts.append(input_case)
-        
+
     if whitelist_file:
         filename_parts.append(Path(whitelist_file).stem)
-        
+
     filename_parts.append(operation)
-    
+
     filename = "_".join(filename_parts) + ".far"
     return os.path.join(cache_dir, filename)
 
@@ -374,15 +374,12 @@ class GraphFst:
         Args:
             fst: input fst.
             project: if True, adds input projection with brackets
-            
+
         """
         if self.project_input:
             # Match input content: either NEMO_NOT_QUOTE or NEMO_NOT_QUOTE followed by a single quote
             # This handles cases like '12"' where input ends with a quote character
-            input_content = pynini.union(
-                pynini.closure(NEMO_NOT_QUOTE, 1),
-                pynini.closure(NEMO_NOT_QUOTE, 1) + "\""
-            )
+            input_content = pynini.union(pynini.closure(NEMO_NOT_QUOTE, 1), pynini.closure(NEMO_NOT_QUOTE, 1) + "\"")
             input_projection = (
                 pynutil.delete(" input: \"")
                 + pynutil.insert(r"\[")
@@ -391,7 +388,7 @@ class GraphFst:
                 + pynutil.delete("\"")
             )
             input_projection = pynini.closure(input_projection, 0, 1)
-            
+
             # Wrap main output in brackets when projecting input
             bracketed_fst = pynutil.insert(r"\[") + fst + pynutil.insert(r"\]")
             fst = bracketed_fst + input_projection

--- a/nemo_text_processing/text_normalization/en/graph_utils.py
+++ b/nemo_text_processing/text_normalization/en/graph_utils.py
@@ -217,8 +217,8 @@ def generate_far_filename(
     """
     filename_parts = [language, mode]
 
-    if deterministic:
-        filename_parts.append("deterministic")
+    if not deterministic:
+        filename_parts.append("non-deterministic")
 
     if project_input:
         filename_parts.append("projecting")

--- a/nemo_text_processing/text_normalization/en/taggers/abbreviation.py
+++ b/nemo_text_processing/text_normalization/en/taggers/abbreviation.py
@@ -30,8 +30,8 @@ class AbbreviationFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, whitelist: 'pynini.FstLike', deterministic: bool = True):
-        super().__init__(name="abbreviation", kind="classify", deterministic=deterministic)
+    def __init__(self, whitelist: 'pynini.FstLike', deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="abbreviation", kind="classify", deterministic=deterministic, project_input=project_input)
 
         dot = pynini.accep(".")
         # A.B.C. -> A. B. C.

--- a/nemo_text_processing/text_normalization/en/taggers/abbreviation.py
+++ b/nemo_text_processing/text_normalization/en/taggers/abbreviation.py
@@ -31,7 +31,9 @@ class AbbreviationFst(GraphFst):
     """
 
     def __init__(self, whitelist: 'pynini.FstLike', deterministic: bool = True, project_input: bool = False):
-        super().__init__(name="abbreviation", kind="classify", deterministic=deterministic, project_input=project_input)
+        super().__init__(
+            name="abbreviation", kind="classify", deterministic=deterministic, project_input=project_input
+        )
 
         dot = pynini.accep(".")
         # A.B.C. -> A. B. C.

--- a/nemo_text_processing/text_normalization/en/taggers/cardinal.py
+++ b/nemo_text_processing/text_normalization/en/taggers/cardinal.py
@@ -38,8 +38,8 @@ class CardinalFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True, lm: bool = False):
-        super().__init__(name="cardinal", kind="classify", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, lm: bool = False, project_input: bool = False):
+        super().__init__(name="cardinal", kind="classify", deterministic=deterministic, project_input=project_input)
 
         self.lm = lm
         self.deterministic = deterministic

--- a/nemo_text_processing/text_normalization/en/taggers/date.py
+++ b/nemo_text_processing/text_normalization/en/taggers/date.py
@@ -174,8 +174,8 @@ class DateFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal: GraphFst, deterministic: bool, lm: bool = False):
-        super().__init__(name="date", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal: GraphFst, deterministic: bool, lm: bool = False, project_input: bool = False):
+        super().__init__(name="date", kind="classify", deterministic=deterministic, project_input=project_input)
 
         # january
         month_graph = pynini.string_file(get_abs_path("data/date/month_name.tsv")).optimize()

--- a/nemo_text_processing/text_normalization/en/taggers/decimal.py
+++ b/nemo_text_processing/text_normalization/en/taggers/decimal.py
@@ -70,8 +70,8 @@ class DecimalFst(GraphFst):
     cardinal: CardinalFst
     """
 
-    def __init__(self, cardinal: GraphFst, deterministic: bool):
-        super().__init__(name="decimal", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal: GraphFst, deterministic: bool, project_input: bool = False):
+        super().__init__(name="decimal", kind="classify", deterministic=deterministic, project_input=project_input)
 
         cardinal_graph = cardinal.graph_with_and
         cardinal_graph_hundred_component_at_least_one_none_zero_digit = (

--- a/nemo_text_processing/text_normalization/en/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/en/taggers/electronic.py
@@ -41,8 +41,8 @@ class ElectronicFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal: GraphFst, deterministic: bool = True):
-        super().__init__(name="electronic", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal: GraphFst, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="electronic", kind="classify", deterministic=deterministic, project_input=project_input)
 
         if deterministic:
             numbers = NEMO_DIGIT

--- a/nemo_text_processing/text_normalization/en/taggers/fraction.py
+++ b/nemo_text_processing/text_normalization/en/taggers/fraction.py
@@ -31,8 +31,8 @@ class FractionFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal, deterministic: bool = True):
-        super().__init__(name="fraction", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="fraction", kind="classify", deterministic=deterministic, project_input=project_input)
         cardinal_graph = cardinal.graph
 
         integer = pynutil.insert("integer_part: \"") + cardinal_graph + pynutil.insert("\"")

--- a/nemo_text_processing/text_normalization/en/taggers/measure.py
+++ b/nemo_text_processing/text_normalization/en/taggers/measure.py
@@ -53,13 +53,9 @@ class MeasureFst(GraphFst):
     """
 
     def __init__(
-        self,
-        cardinal: GraphFst,
-        decimal: GraphFst,
-        fraction: GraphFst,
-        deterministic: bool = True,
+        self, cardinal: GraphFst, decimal: GraphFst, fraction: GraphFst, deterministic: bool = True, project_input: bool = False,
     ):
-        super().__init__(name="measure", kind="classify", deterministic=deterministic)
+        super().__init__(name="measure", kind="classify", deterministic=deterministic, project_input=project_input)
         cardinal_graph = cardinal.graph_with_and | self.get_range(cardinal.graph_with_and)
 
         graph_unit = pynini.string_file(get_abs_path("data/measure/unit.tsv"))

--- a/nemo_text_processing/text_normalization/en/taggers/measure.py
+++ b/nemo_text_processing/text_normalization/en/taggers/measure.py
@@ -53,7 +53,12 @@ class MeasureFst(GraphFst):
     """
 
     def __init__(
-        self, cardinal: GraphFst, decimal: GraphFst, fraction: GraphFst, deterministic: bool = True, project_input: bool = False,
+        self,
+        cardinal: GraphFst,
+        decimal: GraphFst,
+        fraction: GraphFst,
+        deterministic: bool = True,
+        project_input: bool = False,
     ):
         super().__init__(name="measure", kind="classify", deterministic=deterministic, project_input=project_input)
         cardinal_graph = cardinal.graph_with_and | self.get_range(cardinal.graph_with_and)

--- a/nemo_text_processing/text_normalization/en/taggers/money.py
+++ b/nemo_text_processing/text_normalization/en/taggers/money.py
@@ -51,8 +51,8 @@ class MoneyFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal: GraphFst, decimal: GraphFst, deterministic: bool = True):
-        super().__init__(name="money", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal: GraphFst, decimal: GraphFst, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="money", kind="classify", deterministic=deterministic, project_input=project_input)
         cardinal_graph = cardinal.graph_with_and
         graph_decimal_final = decimal.final_graph_wo_negative_w_abbr
 

--- a/nemo_text_processing/text_normalization/en/taggers/ordinal.py
+++ b/nemo_text_processing/text_normalization/en/taggers/ordinal.py
@@ -30,8 +30,8 @@ class OrdinalFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal: GraphFst, deterministic: bool = True):
-        super().__init__(name="ordinal", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal: GraphFst, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="ordinal", kind="classify", deterministic=deterministic, project_input=project_input)
 
         cardinal_graph = cardinal.graph
         cardinal_format = pynini.closure(NEMO_DIGIT | pynini.accep(","))

--- a/nemo_text_processing/text_normalization/en/taggers/punctuation.py
+++ b/nemo_text_processing/text_normalization/en/taggers/punctuation.py
@@ -34,8 +34,8 @@ class PunctuationFst(GraphFst):
 
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="punctuation", kind="classify", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="punctuation", kind="classify", deterministic=deterministic, project_input=project_input)
         s = "!#%&\'()*+,-./:;<=>?@^_`{|}~\""
 
         punct_symbols_to_exclude = ["[", "]"]

--- a/nemo_text_processing/text_normalization/en/taggers/range.py
+++ b/nemo_text_processing/text_normalization/en/taggers/range.py
@@ -38,9 +38,10 @@ class RangeFst(GraphFst):
         date: GraphFst,
         cardinal: GraphFst,
         deterministic: bool = True,
-        lm: bool = False,
+        project_input: bool = False,
+        lm: bool = False
     ):
-        super().__init__(name="range", kind="classify", deterministic=deterministic)
+        super().__init__(name="range", kind="classify", deterministic=deterministic, project_input=project_input)
 
         delete_space = pynini.closure(pynutil.delete(" "), 0, 1)
 
@@ -125,4 +126,5 @@ class RangeFst(GraphFst):
 
         self.graph = self.graph.optimize()
         graph = pynutil.insert("name: \"") + convert_space(self.graph).optimize() + pynutil.insert("\"")
-        self.fst = graph.optimize()
+        final_graph = self.add_tokens(graph)
+        self.fst = final_graph.optimize()

--- a/nemo_text_processing/text_normalization/en/taggers/range.py
+++ b/nemo_text_processing/text_normalization/en/taggers/range.py
@@ -39,7 +39,7 @@ class RangeFst(GraphFst):
         cardinal: GraphFst,
         deterministic: bool = True,
         project_input: bool = False,
-        lm: bool = False
+        lm: bool = False,
     ):
         super().__init__(name="range", kind="classify", deterministic=deterministic, project_input=project_input)
 

--- a/nemo_text_processing/text_normalization/en/taggers/roman.py
+++ b/nemo_text_processing/text_normalization/en/taggers/roman.py
@@ -30,8 +30,8 @@ class RomanFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True, lm: bool = False):
-        super().__init__(name="roman", kind="classify", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, lm: bool = False, project_input: bool = False):
+        super().__init__(name="roman", kind="classify", deterministic=deterministic, project_input=project_input)
 
         roman_dict = load_labels(get_abs_path("data/roman/roman_to_spoken.tsv"))
         default_graph = pynini.string_map(roman_dict).optimize()

--- a/nemo_text_processing/text_normalization/en/taggers/serial.py
+++ b/nemo_text_processing/text_normalization/en/taggers/serial.py
@@ -41,8 +41,15 @@ class SerialFst(GraphFst):
         lm: whether to use for hybrid LM
     """
 
-    def __init__(self, cardinal: GraphFst, ordinal: GraphFst, deterministic: bool = True, lm: bool = False):
-        super().__init__(name="integer", kind="classify", deterministic=deterministic)
+    def __init__(
+        self,
+        cardinal: GraphFst,
+        ordinal: GraphFst,
+        deterministic: bool = True,
+        project_input: bool = False,
+        lm: bool = False
+    ):
+        super().__init__(name="serial", kind="classify", deterministic=deterministic, project_input=project_input)
 
         """
         Finite state transducer for classifying serial (handles only cases without delimiters,
@@ -138,6 +145,7 @@ class SerialFst(GraphFst):
             serial_graph,
         )
 
-        self.graph = serial_graph.optimize()
-        graph = pynutil.insert("name: \"") + convert_space(self.graph).optimize() + pynutil.insert("\"")
-        self.fst = graph.optimize()
+        graph = serial_graph.optimize()
+        graph = pynutil.insert("number: \"") + convert_space(graph) + pynutil.insert("\"")
+        final_graph = self.add_tokens(graph)
+        self.fst = final_graph.optimize()

--- a/nemo_text_processing/text_normalization/en/taggers/serial.py
+++ b/nemo_text_processing/text_normalization/en/taggers/serial.py
@@ -47,7 +47,7 @@ class SerialFst(GraphFst):
         ordinal: GraphFst,
         deterministic: bool = True,
         project_input: bool = False,
-        lm: bool = False
+        lm: bool = False,
     ):
         super().__init__(name="serial", kind="classify", deterministic=deterministic, project_input=project_input)
 

--- a/nemo_text_processing/text_normalization/en/taggers/telephone.py
+++ b/nemo_text_processing/text_normalization/en/taggers/telephone.py
@@ -42,8 +42,8 @@ class TelephoneFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="telephone", kind="classify", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="telephone", kind="classify", deterministic=deterministic, project_input=project_input)
 
         add_separator = pynutil.insert(", ")  # between components
         zero = pynini.cross("0", "zero")

--- a/nemo_text_processing/text_normalization/en/taggers/time.py
+++ b/nemo_text_processing/text_normalization/en/taggers/time.py
@@ -48,8 +48,8 @@ class TimeFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal: GraphFst, deterministic: bool = True):
-        super().__init__(name="time", kind="classify", deterministic=deterministic)
+    def __init__(self, cardinal: GraphFst, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="time", kind="classify", deterministic=deterministic, project_input=project_input)
         suffix_labels = load_labels(get_abs_path("data/time/suffix.tsv"))
         suffix_labels.extend(augment_labels_with_punct_at_end(suffix_labels))
         suffix_graph = pynini.string_map(suffix_labels)

--- a/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify.py
@@ -24,6 +24,7 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_extra_space,
     delete_space,
     generator_main,
+    generate_far_filename,
 )
 from nemo_text_processing.text_normalization.en.taggers.abbreviation import AbbreviationFst
 from nemo_text_processing.text_normalization.en.taggers.cardinal import CardinalFst
@@ -67,6 +68,7 @@ class ClassifyFst(GraphFst):
         self,
         input_case: str,
         deterministic: bool = True,
+        project_input: bool = False,
         cache_dir: str = None,
         overwrite_cache: bool = False,
         whitelist: str = None,
@@ -77,9 +79,15 @@ class ClassifyFst(GraphFst):
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
-            far_file = os.path.join(
-                cache_dir,
-                f"en_tn_{deterministic}_deterministic_{input_case}_{whitelist_file}_tokenize.far",
+            far_file = generate_far_filename(
+                language="en",
+                mode="tn", 
+                cache_dir=cache_dir,
+                operation="tokenize",
+                deterministic=deterministic,
+                project_input=project_input,
+                input_case=input_case,
+                whitelist_file=whitelist_file
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -88,85 +96,77 @@ class ClassifyFst(GraphFst):
             logger.info(f"Creating ClassifyFst grammars.")
 
             start_time = time.time()
-            cardinal = CardinalFst(deterministic=deterministic)
+            cardinal = CardinalFst(deterministic=deterministic, project_input=project_input)
             cardinal_graph = cardinal.fst
             logger.debug(f"cardinal: {time.time() - start_time: .2f}s -- {cardinal_graph.num_states()} nodes")
 
             start_time = time.time()
-            ordinal = OrdinalFst(cardinal=cardinal, deterministic=deterministic)
+            ordinal = OrdinalFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input)
             ordinal_graph = ordinal.fst
             logger.debug(f"ordinal: {time.time() - start_time: .2f}s -- {ordinal_graph.num_states()} nodes")
 
             start_time = time.time()
-            decimal = DecimalFst(cardinal=cardinal, deterministic=deterministic)
+            decimal = DecimalFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input)
             decimal_graph = decimal.fst
             logger.debug(f"decimal: {time.time() - start_time: .2f}s -- {decimal_graph.num_states()} nodes")
 
             start_time = time.time()
-            fraction = FractionFst(deterministic=deterministic, cardinal=cardinal)
+            fraction = FractionFst(deterministic=deterministic, cardinal=cardinal, project_input=project_input)
             fraction_graph = fraction.fst
             logger.debug(f"fraction: {time.time() - start_time: .2f}s -- {fraction_graph.num_states()} nodes")
 
             start_time = time.time()
-            measure = MeasureFst(
-                cardinal=cardinal,
-                decimal=decimal,
-                fraction=fraction,
-                deterministic=deterministic,
-            )
+            measure = MeasureFst(cardinal=cardinal, decimal=decimal, fraction=fraction, deterministic=deterministic, project_input=project_input)
             measure_graph = measure.fst
             logger.debug(f"measure: {time.time() - start_time: .2f}s -- {measure_graph.num_states()} nodes")
 
             start_time = time.time()
-            date_graph = DateFst(cardinal=cardinal, deterministic=deterministic).fst
+            date_graph = DateFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"date: {time.time() - start_time: .2f}s -- {date_graph.num_states()} nodes")
 
             start_time = time.time()
-            time_graph = TimeFst(cardinal=cardinal, deterministic=deterministic).fst
+            time_graph = TimeFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"time: {time.time() - start_time: .2f}s -- {time_graph.num_states()} nodes")
 
             start_time = time.time()
-            telephone_graph = TelephoneFst(deterministic=deterministic).fst
+            telephone_graph = TelephoneFst(deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"telephone: {time.time() - start_time: .2f}s -- {telephone_graph.num_states()} nodes")
 
             start_time = time.time()
-            electonic_graph = ElectronicFst(cardinal=cardinal, deterministic=deterministic).fst
+            electonic_graph = ElectronicFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"electronic: {time.time() - start_time: .2f}s -- {electonic_graph.num_states()} nodes")
 
             start_time = time.time()
-            money_graph = MoneyFst(cardinal=cardinal, decimal=decimal, deterministic=deterministic).fst
+            money_graph = MoneyFst(cardinal=cardinal, decimal=decimal, deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"money: {time.time() - start_time: .2f}s -- {money_graph.num_states()} nodes")
 
             start_time = time.time()
             whitelist_graph = WhiteListFst(
-                input_case=input_case, deterministic=deterministic, input_file=whitelist
+                input_case=input_case, deterministic=deterministic, input_file=whitelist, project_input=project_input
             ).fst
             logger.debug(f"whitelist: {time.time() - start_time: .2f}s -- {whitelist_graph.num_states()} nodes")
 
             start_time = time.time()
-            punctuation = PunctuationFst(deterministic=deterministic)
+            punctuation = PunctuationFst(deterministic=deterministic, project_input=project_input)
             punct_graph = punctuation.fst
             logger.debug(f"punct: {time.time() - start_time: .2f}s -- {punct_graph.num_states()} nodes")
 
             start_time = time.time()
-            word_graph = WordFst(punctuation=punctuation, deterministic=deterministic).fst
+            word_graph = WordFst(punctuation=punctuation, deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"word: {time.time() - start_time: .2f}s -- {word_graph.num_states()} nodes")
 
             start_time = time.time()
-            serial_graph = SerialFst(cardinal=cardinal, ordinal=ordinal, deterministic=deterministic).fst
+            serial_graph = SerialFst(cardinal=cardinal, ordinal=ordinal, deterministic=deterministic, project_input=project_input).fst
             logger.debug(f"serial: {time.time() - start_time: .2f}s -- {serial_graph.num_states()} nodes")
 
             start_time = time.time()
-            v_time_graph = vTimeFst(deterministic=deterministic).fst
-            v_ordinal_graph = vOrdinalFst(deterministic=deterministic)
-            v_date_graph = vDateFst(ordinal=v_ordinal_graph, deterministic=deterministic).fst
+            v_time_graph = vTimeFst(deterministic=deterministic, project_input=project_input).fst
+            v_ordinal_graph = vOrdinalFst(deterministic=deterministic, project_input=project_input)
+            v_date_graph = vDateFst(ordinal=v_ordinal_graph, deterministic=deterministic, project_input=project_input).fst
             time_final = pynini.compose(time_graph, v_time_graph)
             date_final = pynini.compose(date_graph, v_date_graph)
             range_graph = RangeFst(
-                time=time_final,
-                date=date_final,
-                cardinal=cardinal,
-                deterministic=deterministic,
+                time=time_final, date=date_final, cardinal=cardinal, deterministic=deterministic, project_input=project_input
             ).fst
             logger.debug(f"range: {time.time() - start_time: .2f}s -- {range_graph.num_states()} nodes")
 
@@ -198,16 +198,16 @@ class ClassifyFst(GraphFst):
                 | pynutil.add_weight(telephone_graph, 1.1)
                 | pynutil.add_weight(electonic_graph, 1.11)
                 | pynutil.add_weight(fraction_graph, 1.1)
-                | pynutil.add_weight(range_graph, 1.1)
+                | pynutil.add_weight(range_graph, 1.11)
                 | pynutil.add_weight(serial_graph, 1.12)  # should be higher than the rest of the classes
                 | pynutil.add_weight(graph_range_money, 1.1)
             )
 
-            # roman_graph = RomanFst(deterministic=deterministic).fst
-            # classify |= pynutil.add_weight(roman_graph, 1.1)
+            roman_graph = RomanFst(deterministic=deterministic, project_input=project_input).fst
+            classify |= pynutil.add_weight(roman_graph, 1.1)
 
             if not deterministic:
-                abbreviation_graph = AbbreviationFst(deterministic=deterministic).fst
+                abbreviation_graph = AbbreviationFst(deterministic=deterministic, project_input=project_input).fst
                 classify |= pynutil.add_weight(abbreviation_graph, 100)
 
             punct = pynutil.insert("tokens { ") + pynutil.add_weight(punct_graph, weight=2.1) + pynutil.insert(" }")

--- a/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify.py
@@ -23,8 +23,8 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     GraphFst,
     delete_extra_space,
     delete_space,
-    generator_main,
     generate_far_filename,
+    generator_main,
 )
 from nemo_text_processing.text_normalization.en.taggers.abbreviation import AbbreviationFst
 from nemo_text_processing.text_normalization.en.taggers.cardinal import CardinalFst
@@ -81,13 +81,13 @@ class ClassifyFst(GraphFst):
             whitelist_file = os.path.basename(whitelist) if whitelist else ""
             far_file = generate_far_filename(
                 language="en",
-                mode="tn", 
+                mode="tn",
                 cache_dir=cache_dir,
                 operation="tokenize",
                 deterministic=deterministic,
                 project_input=project_input,
                 input_case=input_case,
-                whitelist_file=whitelist_file
+                whitelist_file=whitelist_file,
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["tokenize_and_classify"]
@@ -116,7 +116,13 @@ class ClassifyFst(GraphFst):
             logger.debug(f"fraction: {time.time() - start_time: .2f}s -- {fraction_graph.num_states()} nodes")
 
             start_time = time.time()
-            measure = MeasureFst(cardinal=cardinal, decimal=decimal, fraction=fraction, deterministic=deterministic, project_input=project_input)
+            measure = MeasureFst(
+                cardinal=cardinal,
+                decimal=decimal,
+                fraction=fraction,
+                deterministic=deterministic,
+                project_input=project_input,
+            )
             measure_graph = measure.fst
             logger.debug(f"measure: {time.time() - start_time: .2f}s -- {measure_graph.num_states()} nodes")
 
@@ -133,11 +139,15 @@ class ClassifyFst(GraphFst):
             logger.debug(f"telephone: {time.time() - start_time: .2f}s -- {telephone_graph.num_states()} nodes")
 
             start_time = time.time()
-            electonic_graph = ElectronicFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input).fst
+            electonic_graph = ElectronicFst(
+                cardinal=cardinal, deterministic=deterministic, project_input=project_input
+            ).fst
             logger.debug(f"electronic: {time.time() - start_time: .2f}s -- {electonic_graph.num_states()} nodes")
 
             start_time = time.time()
-            money_graph = MoneyFst(cardinal=cardinal, decimal=decimal, deterministic=deterministic, project_input=project_input).fst
+            money_graph = MoneyFst(
+                cardinal=cardinal, decimal=decimal, deterministic=deterministic, project_input=project_input
+            ).fst
             logger.debug(f"money: {time.time() - start_time: .2f}s -- {money_graph.num_states()} nodes")
 
             start_time = time.time()
@@ -156,17 +166,25 @@ class ClassifyFst(GraphFst):
             logger.debug(f"word: {time.time() - start_time: .2f}s -- {word_graph.num_states()} nodes")
 
             start_time = time.time()
-            serial_graph = SerialFst(cardinal=cardinal, ordinal=ordinal, deterministic=deterministic, project_input=project_input).fst
+            serial_graph = SerialFst(
+                cardinal=cardinal, ordinal=ordinal, deterministic=deterministic, project_input=project_input
+            ).fst
             logger.debug(f"serial: {time.time() - start_time: .2f}s -- {serial_graph.num_states()} nodes")
 
             start_time = time.time()
             v_time_graph = vTimeFst(deterministic=deterministic, project_input=project_input).fst
             v_ordinal_graph = vOrdinalFst(deterministic=deterministic, project_input=project_input)
-            v_date_graph = vDateFst(ordinal=v_ordinal_graph, deterministic=deterministic, project_input=project_input).fst
+            v_date_graph = vDateFst(
+                ordinal=v_ordinal_graph, deterministic=deterministic, project_input=project_input
+            ).fst
             time_final = pynini.compose(time_graph, v_time_graph)
             date_final = pynini.compose(date_graph, v_date_graph)
             range_graph = RangeFst(
-                time=time_final, date=date_final, cardinal=cardinal, deterministic=deterministic, project_input=project_input
+                time=time_final,
+                date=date_final,
+                cardinal=cardinal,
+                deterministic=deterministic,
+                project_input=project_input,
             ).fst
             logger.debug(f"range: {time.time() - start_time: .2f}s -- {range_graph.num_states()} nodes")
 

--- a/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_lm.py
+++ b/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_lm.py
@@ -82,7 +82,7 @@ class ClassifyFst(GraphFst):
         project_input: bool = False,
         cache_dir: str = None,
         overwrite_cache: bool = True,
-        whitelist: str = None
+        whitelist: str = None,
     ):
         super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
 

--- a/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_lm.py
+++ b/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_lm.py
@@ -79,9 +79,10 @@ class ClassifyFst(GraphFst):
         self,
         input_case: str,
         deterministic: bool = True,
+        project_input: bool = False,
         cache_dir: str = None,
         overwrite_cache: bool = True,
-        whitelist: str = None,
+        whitelist: str = None
     ):
         super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
 

--- a/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_with_audio.py
+++ b/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_with_audio.py
@@ -82,7 +82,7 @@ class ClassifyFst(GraphFst):
         project_input: bool = False,
         cache_dir: str = None,
         overwrite_cache: bool = True,
-        whitelist: str = None
+        whitelist: str = None,
     ):
         super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
 

--- a/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_with_audio.py
+++ b/nemo_text_processing/text_normalization/en/taggers/tokenize_and_classify_with_audio.py
@@ -79,9 +79,10 @@ class ClassifyFst(GraphFst):
         self,
         input_case: str,
         deterministic: bool = True,
+        project_input: bool = False,
         cache_dir: str = None,
         overwrite_cache: bool = True,
-        whitelist: str = None,
+        whitelist: str = None
     ):
         super().__init__(name="tokenize_and_classify", kind="classify", deterministic=deterministic)
 

--- a/nemo_text_processing/text_normalization/en/taggers/whitelist.py
+++ b/nemo_text_processing/text_normalization/en/taggers/whitelist.py
@@ -52,11 +52,7 @@ class WhiteListFst(GraphFst):
     """
 
     def __init__(
-        self,
-        input_case: str,
-        deterministic: bool = True,
-        project_input: bool = False,
-        input_file: str = None
+        self, input_case: str, deterministic: bool = True, project_input: bool = False, input_file: str = None
     ):
         super().__init__(name="whitelist", kind="classify", deterministic=deterministic, project_input=project_input)
 

--- a/nemo_text_processing/text_normalization/en/taggers/whitelist.py
+++ b/nemo_text_processing/text_normalization/en/taggers/whitelist.py
@@ -51,8 +51,14 @@ class WhiteListFst(GraphFst):
         input_file: path to a file with whitelist replacements
     """
 
-    def __init__(self, input_case: str, deterministic: bool = True, input_file: str = None):
-        super().__init__(name="whitelist", kind="classify", deterministic=deterministic)
+    def __init__(
+        self,
+        input_case: str,
+        deterministic: bool = True,
+        project_input: bool = False,
+        input_file: str = None
+    ):
+        super().__init__(name="whitelist", kind="classify", deterministic=deterministic, project_input=project_input)
 
         def _get_whitelist_graph(input_case, file, keep_punct_add_end: bool = False):
             whitelist = load_labels(file)
@@ -129,7 +135,9 @@ class WhiteListFst(GraphFst):
 
         self.graph = (convert_space(graph)).optimize()
 
-        self.fst = (pynutil.insert("name: \"") + self.graph + pynutil.insert("\"")).optimize()
+        final_graph = pynutil.insert("name: \"") + self.graph + pynutil.insert("\"")
+        final_graph = self.add_tokens(final_graph)
+        self.fst = final_graph.optimize()
 
 
 def get_formats(input_f, input_case=INPUT_CASED, is_default=True):

--- a/nemo_text_processing/text_normalization/en/taggers/word.py
+++ b/nemo_text_processing/text_normalization/en/taggers/word.py
@@ -40,12 +40,7 @@ class WordFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(
-        self,
-        punctuation: GraphFst,
-        deterministic: bool = True,
-        project_input: bool = False
-    ):
+    def __init__(self, punctuation: GraphFst, deterministic: bool = True, project_input: bool = False):
         super().__init__(name="word", kind="classify", deterministic=deterministic, project_input=project_input)
 
         punct = PunctuationFst().graph

--- a/nemo_text_processing/text_normalization/en/taggers/word.py
+++ b/nemo_text_processing/text_normalization/en/taggers/word.py
@@ -40,8 +40,13 @@ class WordFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, punctuation: GraphFst, deterministic: bool = True):
-        super().__init__(name="word", kind="classify", deterministic=deterministic)
+    def __init__(
+        self,
+        punctuation: GraphFst,
+        deterministic: bool = True,
+        project_input: bool = False
+    ):
+        super().__init__(name="word", kind="classify", deterministic=deterministic, project_input=project_input)
 
         punct = PunctuationFst().graph
         default_graph = pynini.closure(pynini.difference(NEMO_NOT_SPACE, punct.project("input")), 1)

--- a/nemo_text_processing/text_normalization/en/verbalizers/abbreviation.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/abbreviation.py
@@ -29,7 +29,9 @@ class AbbreviationFst(GraphFst):
     """
 
     def __init__(self, deterministic: bool = True, project_input: bool = False):
-        super().__init__(name="abbreviation", kind="verbalize", deterministic=deterministic, project_input=project_input)
+        super().__init__(
+            name="abbreviation", kind="verbalize", deterministic=deterministic, project_input=project_input
+        )
 
         graph = pynutil.delete("value: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
         delete_tokens = self.delete_tokens(graph)

--- a/nemo_text_processing/text_normalization/en/verbalizers/cardinal.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/cardinal.py
@@ -28,8 +28,8 @@ class CardinalFst(GraphFst):
             for False multiple options (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="cardinal", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="cardinal", kind="verbalize", deterministic=deterministic, project_input=project_input)
 
         self.optional_sign = pynini.cross("negative: \"true\"", "minus ")
         if not deterministic:

--- a/nemo_text_processing/text_normalization/en/verbalizers/date.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/date.py
@@ -37,8 +37,8 @@ class DateFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, ordinal: GraphFst, deterministic: bool = True, lm: bool = False):
-        super().__init__(name="date", kind="verbalize", deterministic=deterministic)
+    def __init__(self, ordinal: GraphFst, deterministic: bool = True, lm: bool = False, project_input: bool = False):
+        super().__init__(name="date", kind="verbalize", deterministic=deterministic, project_input=project_input)
 
         phrase = pynini.closure(NEMO_NOT_QUOTE, 1)
         day_cardinal = (

--- a/nemo_text_processing/text_normalization/en/verbalizers/decimal.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/decimal.py
@@ -34,8 +34,8 @@ class DecimalFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, cardinal, deterministic: bool = True):
-        super().__init__(name="decimal", kind="verbalize", deterministic=deterministic)
+    def __init__(self, cardinal, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="decimal", kind="verbalize", deterministic=deterministic, project_input=project_input)
         self.optional_sign = pynini.cross("negative: \"true\"", "minus ")
         if not deterministic:
             self.optional_sign |= pynini.cross("negative: \"true\"", "negative ")

--- a/nemo_text_processing/text_normalization/en/verbalizers/electronic.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/electronic.py
@@ -43,8 +43,8 @@ class ElectronicFst(GraphFst):
         for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="electronic", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="electronic", kind="verbalize", deterministic=deterministic, project_input=project_input)
         graph_digit_no_zero = pynini.invert(pynini.string_file(get_abs_path("data/number/digit.tsv"))).optimize()
         graph_zero = pynini.cross("0", "zero")
         long_numbers = pynutil.add_weight(graph_digit_no_zero + pynini.cross("000", " thousand"), MIN_NEG_WEIGHT)
@@ -55,7 +55,7 @@ class ElectronicFst(GraphFst):
         graph_digit = graph_digit_no_zero | graph_zero
         graph_symbols = pynini.string_file(get_abs_path("data/electronic/symbol.tsv")).optimize()
 
-        NEMO_NOT_BRACKET = pynini.difference(NEMO_CHAR, pynini.union("{", "}")).optimize()
+        NEMO_NOT_BRACKET = pynini.difference(NEMO_CHAR, pynini.union("{", "}", '"')).optimize()
         dict_words = pynini.project(pynini.string_file(get_abs_path("data/electronic/words.tsv")), "output")
         default_chars_symbols = pynini.cdrewrite(
             pynutil.insert(" ") + (graph_symbols | graph_digit | long_numbers) + pynutil.insert(" "),

--- a/nemo_text_processing/text_normalization/en/verbalizers/fraction.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/fraction.py
@@ -31,8 +31,8 @@ class FractionFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True, lm: bool = False):
-        super().__init__(name="fraction", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, lm: bool = False, project_input: bool = False):
+        super().__init__(name="fraction", kind="verbalize", deterministic=deterministic, project_input=project_input)
         suffix = OrdinalFst().suffix
 
         integer = pynutil.delete("integer_part: \"") + pynini.closure(NEMO_NOT_QUOTE) + pynutil.delete("\" ")

--- a/nemo_text_processing/text_normalization/en/verbalizers/measure.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/measure.py
@@ -39,7 +39,14 @@ class MeasureFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, decimal: GraphFst, cardinal: GraphFst, fraction: GraphFst, deterministic: bool = True, project_input: bool = False):
+    def __init__(
+        self,
+        decimal: GraphFst,
+        cardinal: GraphFst,
+        fraction: GraphFst,
+        deterministic: bool = True,
+        project_input: bool = False,
+    ):
         super().__init__(name="measure", kind="verbalize", deterministic=deterministic, project_input=project_input)
         optional_sign = cardinal.optional_sign
         unit = (

--- a/nemo_text_processing/text_normalization/en/verbalizers/measure.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/measure.py
@@ -39,8 +39,8 @@ class MeasureFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, decimal: GraphFst, cardinal: GraphFst, fraction: GraphFst, deterministic: bool = True):
-        super().__init__(name="measure", kind="verbalize", deterministic=deterministic)
+    def __init__(self, decimal: GraphFst, cardinal: GraphFst, fraction: GraphFst, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="measure", kind="verbalize", deterministic=deterministic, project_input=project_input)
         optional_sign = cardinal.optional_sign
         unit = (
             pynutil.delete("units: \"")

--- a/nemo_text_processing/text_normalization/en/verbalizers/money.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/money.py
@@ -38,8 +38,8 @@ class MoneyFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, decimal: GraphFst, deterministic: bool = True):
-        super().__init__(name="money", kind="verbalize", deterministic=deterministic)
+    def __init__(self, decimal: GraphFst, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="money", kind="verbalize", deterministic=deterministic, project_input=project_input)
         keep_space = pynini.accep(" ")
         maj = pynutil.delete('currency_maj: "') + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete('"')
         min = pynutil.delete('currency_min: "') + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete('"')
@@ -77,7 +77,7 @@ class MoneyFst(GraphFst):
             pynutil.delete(' morphosyntactic_features: "')
             + pynutil.insert(" ")
             + per_units_normalized
-            + pynutil.delete('" ')
+            + pynutil.delete('"')
         )
         graph += remove_per_units_normalized.ques
 

--- a/nemo_text_processing/text_normalization/en/verbalizers/ordinal.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/ordinal.py
@@ -30,8 +30,8 @@ class OrdinalFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="ordinal", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="ordinal", kind="verbalize", deterministic=deterministic, project_input=project_input)
 
         graph_digit = pynini.string_file(get_abs_path("data/ordinal/digit.tsv")).invert()
         graph_teens = pynini.string_file(get_abs_path("data/ordinal/teen.tsv")).invert()

--- a/nemo_text_processing/text_normalization/en/verbalizers/post_processing.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/post_processing.py
@@ -39,11 +39,7 @@ class PostProcessingFst:
         overwrite_cache: set to True to overwrite .far files
     """
 
-    def __init__(
-        self,
-        cache_dir: str = None,
-        overwrite_cache: bool = False
-    ):
+    def __init__(self, cache_dir: str = None, overwrite_cache: bool = False):
 
         far_file = None
         if cache_dir is not None and cache_dir != "None":

--- a/nemo_text_processing/text_normalization/en/verbalizers/range.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/range.py
@@ -36,7 +36,7 @@ class RangeFst(GraphFst):
             + pynini.closure(NEMO_CHAR - " ", 1)
             + pynutil.delete("\"")
         )
-        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
-        
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)
+
         delete_tokens = self.delete_tokens(graph)
         self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/en/verbalizers/roman.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/roman.py
@@ -29,8 +29,8 @@ class RomanFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="roman", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="roman", kind="verbalize", deterministic=deterministic, project_input=project_input)
         suffix = OrdinalFst().suffix
 
         cardinal = pynini.closure(NEMO_NOT_QUOTE)

--- a/nemo_text_processing/text_normalization/en/verbalizers/serial.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/serial.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,17 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import pynini
 from pynini.lib import pynutil
 
-from nemo_text_processing.text_normalization.en.graph_utils import NEMO_NOT_QUOTE, GraphFst
+from nemo_text_processing.text_normalization.en.graph_utils import NEMO_CHAR, NEMO_SIGMA, GraphFst, delete_space
 
 
-class AbbreviationFst(GraphFst):
+class SerialFst(GraphFst):
     """
-    Finite state transducer for verbalizing abbreviations
-        e.g. tokens { abbreviation { value: "A B C" } } -> "ABC"
+    Finite state transducer for verbalizing serial
+        e.g. tokens { serial { "c three two five b" } } -> c three two five b
 
     Args:
         deterministic: if True will provide a single transduction option,
@@ -29,8 +28,15 @@ class AbbreviationFst(GraphFst):
     """
 
     def __init__(self, deterministic: bool = True, project_input: bool = False):
-        super().__init__(name="abbreviation", kind="verbalize", deterministic=deterministic, project_input=project_input)
-
-        graph = pynutil.delete("value: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+        super().__init__(name="serial", kind="verbalize", deterministic=deterministic, project_input=project_input)
+        graph = (
+            pynutil.delete("number:")
+            + delete_space
+            + pynutil.delete("\"")
+            + pynini.closure(NEMO_CHAR - " ", 1)
+            + pynutil.delete("\"")
+        )
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
+        
         delete_tokens = self.delete_tokens(graph)
         self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/en/verbalizers/serial.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/serial.py
@@ -36,7 +36,7 @@ class SerialFst(GraphFst):
             + pynini.closure(NEMO_CHAR - " ", 1)
             + pynutil.delete("\"")
         )
-        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
-        
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)
+
         delete_tokens = self.delete_tokens(graph)
         self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/en/verbalizers/telephone.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/telephone.py
@@ -29,8 +29,8 @@ class TelephoneFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="telephone", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="telephone", kind="verbalize", deterministic=deterministic, project_input=project_input)
 
         optional_country_code = pynini.closure(
             pynutil.delete("country_code: \"")

--- a/nemo_text_processing/text_normalization/en/verbalizers/time.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/time.py
@@ -35,8 +35,8 @@ class TimeFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="time", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="time", kind="verbalize", deterministic=deterministic, project_input=project_input)
         hour = (
             pynutil.delete("hours:")
             + delete_space

--- a/nemo_text_processing/text_normalization/en/verbalizers/verbalize.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/verbalize.py
@@ -22,7 +22,9 @@ from nemo_text_processing.text_normalization.en.verbalizers.fraction import Frac
 from nemo_text_processing.text_normalization.en.verbalizers.measure import MeasureFst
 from nemo_text_processing.text_normalization.en.verbalizers.money import MoneyFst
 from nemo_text_processing.text_normalization.en.verbalizers.ordinal import OrdinalFst
+from nemo_text_processing.text_normalization.en.verbalizers.range import RangeFst
 from nemo_text_processing.text_normalization.en.verbalizers.roman import RomanFst
+from nemo_text_processing.text_normalization.en.verbalizers.serial import SerialFst
 from nemo_text_processing.text_normalization.en.verbalizers.telephone import TelephoneFst
 from nemo_text_processing.text_normalization.en.verbalizers.time import TimeFst
 from nemo_text_processing.text_normalization.en.verbalizers.whitelist import WhiteListFst
@@ -39,24 +41,26 @@ class VerbalizeFst(GraphFst):
             for False multiple options (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
         super().__init__(name="verbalize", kind="verbalize", deterministic=deterministic)
-        cardinal = CardinalFst(deterministic=deterministic)
+        cardinal = CardinalFst(deterministic=deterministic, project_input=project_input)
         cardinal_graph = cardinal.fst
-        decimal = DecimalFst(cardinal=cardinal, deterministic=deterministic)
+        decimal = DecimalFst(cardinal=cardinal, deterministic=deterministic, project_input=project_input)
         decimal_graph = decimal.fst
-        ordinal = OrdinalFst(deterministic=deterministic)
+        ordinal = OrdinalFst(deterministic=deterministic, project_input=project_input)
         ordinal_graph = ordinal.fst
-        fraction = FractionFst(deterministic=deterministic)
+        fraction = FractionFst(deterministic=deterministic, project_input=project_input)
         fraction_graph = fraction.fst
-        telephone_graph = TelephoneFst(deterministic=deterministic).fst
-        electronic_graph = ElectronicFst(deterministic=deterministic).fst
-        measure = MeasureFst(decimal=decimal, cardinal=cardinal, fraction=fraction, deterministic=deterministic)
+        telephone_graph = TelephoneFst(deterministic=deterministic, project_input=project_input).fst
+        electronic_graph = ElectronicFst(deterministic=deterministic, project_input=project_input).fst
+        measure = MeasureFst(decimal=decimal, cardinal=cardinal, fraction=fraction, deterministic=deterministic, project_input=project_input)
         measure_graph = measure.fst
-        time_graph = TimeFst(deterministic=deterministic).fst
-        date_graph = DateFst(ordinal=ordinal, deterministic=deterministic).fst
-        money_graph = MoneyFst(decimal=decimal, deterministic=deterministic).fst
-        whitelist_graph = WhiteListFst(deterministic=deterministic).fst
+        time_graph = TimeFst(deterministic=deterministic, project_input=project_input).fst
+        date_graph = DateFst(ordinal=ordinal, deterministic=deterministic, project_input=project_input).fst
+        money_graph = MoneyFst(decimal=decimal, deterministic=deterministic, project_input=project_input).fst
+        whitelist_graph = WhiteListFst(deterministic=deterministic, project_input=project_input).fst
+        serial_graph = SerialFst(deterministic=deterministic, project_input=project_input).fst
+        range_graph = RangeFst(deterministic=deterministic, project_input=project_input).fst
 
         graph = (
             time_graph
@@ -70,13 +74,15 @@ class VerbalizeFst(GraphFst):
             | electronic_graph
             | fraction_graph
             | whitelist_graph
+            | serial_graph
+            | range_graph
         )
 
-        roman_graph = RomanFst(deterministic=deterministic).fst
+        roman_graph = RomanFst(deterministic=deterministic, project_input=project_input).fst
         graph |= roman_graph
 
         if not deterministic:
-            abbreviation_graph = AbbreviationFst(deterministic=deterministic).fst
+            abbreviation_graph = AbbreviationFst(deterministic=deterministic, project_input=project_input).fst
             graph |= abbreviation_graph
 
         self.fst = graph

--- a/nemo_text_processing/text_normalization/en/verbalizers/verbalize.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/verbalize.py
@@ -53,7 +53,13 @@ class VerbalizeFst(GraphFst):
         fraction_graph = fraction.fst
         telephone_graph = TelephoneFst(deterministic=deterministic, project_input=project_input).fst
         electronic_graph = ElectronicFst(deterministic=deterministic, project_input=project_input).fst
-        measure = MeasureFst(decimal=decimal, cardinal=cardinal, fraction=fraction, deterministic=deterministic, project_input=project_input)
+        measure = MeasureFst(
+            decimal=decimal,
+            cardinal=cardinal,
+            fraction=fraction,
+            deterministic=deterministic,
+            project_input=project_input,
+        )
         measure_graph = measure.fst
         time_graph = TimeFst(deterministic=deterministic, project_input=project_input).fst
         date_graph = DateFst(ordinal=ordinal, deterministic=deterministic, project_input=project_input).fst

--- a/nemo_text_processing/text_normalization/en/verbalizers/verbalize_final.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/verbalize_final.py
@@ -21,8 +21,8 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     GraphFst,
     delete_extra_space,
     delete_space,
-    generator_main,
     generate_far_filename,
+    generator_main,
 )
 from nemo_text_processing.text_normalization.en.verbalizers.verbalize import VerbalizeFst
 from nemo_text_processing.text_normalization.en.verbalizers.word import WordFst
@@ -41,7 +41,13 @@ class VerbalizeFinalFst(GraphFst):
         overwrite_cache: set to True to overwrite .far files
     """
 
-    def __init__(self, deterministic: bool = True, cache_dir: str = None, overwrite_cache: bool = False, project_input: bool = False):
+    def __init__(
+        self,
+        deterministic: bool = True,
+        cache_dir: str = None,
+        overwrite_cache: bool = False,
+        project_input: bool = False,
+    ):
         super().__init__(name="verbalize_final", kind="verbalize", deterministic=deterministic)
 
         far_file = None
@@ -53,7 +59,7 @@ class VerbalizeFinalFst(GraphFst):
                 cache_dir=cache_dir,
                 operation="verbalize",
                 deterministic=deterministic,
-                project_input=project_input
+                project_input=project_input,
             )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["verbalize"]

--- a/nemo_text_processing/text_normalization/en/verbalizers/verbalize_final.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/verbalize_final.py
@@ -22,6 +22,7 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     delete_extra_space,
     delete_space,
     generator_main,
+    generate_far_filename,
 )
 from nemo_text_processing.text_normalization.en.verbalizers.verbalize import VerbalizeFst
 from nemo_text_processing.text_normalization.en.verbalizers.word import WordFst
@@ -40,19 +41,26 @@ class VerbalizeFinalFst(GraphFst):
         overwrite_cache: set to True to overwrite .far files
     """
 
-    def __init__(self, deterministic: bool = True, cache_dir: str = None, overwrite_cache: bool = False):
+    def __init__(self, deterministic: bool = True, cache_dir: str = None, overwrite_cache: bool = False, project_input: bool = False):
         super().__init__(name="verbalize_final", kind="verbalize", deterministic=deterministic)
 
         far_file = None
         if cache_dir is not None and cache_dir != "None":
             os.makedirs(cache_dir, exist_ok=True)
-            far_file = os.path.join(cache_dir, f"en_tn_{deterministic}_deterministic_verbalizer.far")
+            far_file = generate_far_filename(
+                language="en",
+                mode="tn",
+                cache_dir=cache_dir,
+                operation="verbalize",
+                deterministic=deterministic,
+                project_input=project_input
+            )
         if not overwrite_cache and far_file and os.path.exists(far_file):
             self.fst = pynini.Far(far_file, mode="r")["verbalize"]
             logger.info(f'VerbalizeFinalFst graph was restored from {far_file}.')
         else:
-            verbalize = VerbalizeFst(deterministic=deterministic).fst
-            word = WordFst(deterministic=deterministic).fst
+            verbalize = VerbalizeFst(deterministic=deterministic, project_input=project_input).fst
+            word = WordFst(deterministic=deterministic, project_input=project_input).fst
             types = verbalize | word
 
             if deterministic:

--- a/nemo_text_processing/text_normalization/en/verbalizers/whitelist.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/whitelist.py
@@ -36,7 +36,7 @@ class WhiteListFst(GraphFst):
             + pynini.closure(NEMO_CHAR - " ", 1)
             + pynutil.delete("\"")
         )
-        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
-        
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)
+
         delete_tokens = self.delete_tokens(graph)
         self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/en/verbalizers/whitelist.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/whitelist.py
@@ -27,8 +27,8 @@ class WhiteListFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="whitelist", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="whitelist", kind="verbalize", deterministic=deterministic, project_input=project_input)
         graph = (
             pynutil.delete("name:")
             + delete_space
@@ -36,5 +36,7 @@ class WhiteListFst(GraphFst):
             + pynini.closure(NEMO_CHAR - " ", 1)
             + pynutil.delete("\"")
         )
-        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)
-        self.fst = graph.optimize()
+        graph = graph @ pynini.cdrewrite(pynini.cross(u"\u00A0", " "), "", "", NEMO_SIGMA)
+        
+        delete_tokens = self.delete_tokens(graph)
+        self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/en/verbalizers/word.py
+++ b/nemo_text_processing/text_normalization/en/verbalizers/word.py
@@ -27,8 +27,8 @@ class WordFst(GraphFst):
             for False multiple transduction are generated (used for audio-based normalization)
     """
 
-    def __init__(self, deterministic: bool = True):
-        super().__init__(name="word", kind="verbalize", deterministic=deterministic)
+    def __init__(self, deterministic: bool = True, project_input: bool = False):
+        super().__init__(name="word", kind="verbalize", deterministic=deterministic, project_input=project_input)
         chars = pynini.closure(NEMO_CHAR - " ", 1)
         char = pynutil.delete("name:") + delete_space + pynutil.delete("\"") + chars + pynutil.delete("\"")
         graph = char @ pynini.cdrewrite(pynini.cross(u"\u00a0", " "), "", "", NEMO_SIGMA)

--- a/nemo_text_processing/text_normalization/normalize.py
+++ b/nemo_text_processing/text_normalization/normalize.py
@@ -20,10 +20,11 @@ import shutil
 import sys
 from argparse import ArgumentParser
 from collections import OrderedDict
+from copy import deepcopy
 from glob import glob
 from math import factorial
 from time import perf_counter
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 
 import pynini
 import regex
@@ -40,7 +41,7 @@ from nemo_text_processing.text_normalization.data_loader_utils import (
     write_file,
 )
 from nemo_text_processing.text_normalization.preprocessing_utils import additional_split
-from nemo_text_processing.text_normalization.token_parser import PRESERVE_ORDER_KEY, TokenParser
+from nemo_text_processing.text_normalization.token_parser import INPUT_KEY, PRESERVE_ORDER_KEY, TokenParser
 from nemo_text_processing.utils.logging import logger
 
 # this is to handle long input
@@ -106,6 +107,7 @@ class Normalizer:
         input_case: str,
         lang: str = 'en',
         deterministic: bool = True,
+        project_input: bool = False,
         cache_dir: str = None,
         overwrite_cache: bool = False,
         whitelist: str = None,
@@ -186,8 +188,19 @@ class Normalizer:
             whitelist=whitelist,
         )
 
+        self.project_input = project_input
+        if self.project_input:
+            self.tagger_input_projector = ClassifyFst(
+                input_case=self.input_case,
+                deterministic=deterministic,
+                project_input=True,
+                cache_dir=cache_dir,
+                overwrite_cache=overwrite_cache,
+                whitelist=whitelist,
+            )
+
         self.verbalizer = VerbalizeFinalFst(
-            deterministic=deterministic, cache_dir=cache_dir, overwrite_cache=overwrite_cache
+            deterministic=deterministic, cache_dir=cache_dir, overwrite_cache=overwrite_cache, project_input=project_input
         )
         self.max_number_of_permutations_per_split = max_number_of_permutations_per_split
         self.parser = TokenParser()
@@ -318,6 +331,56 @@ class Normalizer:
         assert sum([len(s) for s in splits]) == len(tokens)
         return splits
 
+    @staticmethod
+    def _merge_input_field(source: Any, target: Any) -> Any:
+        """
+        Copy the ``"input"`` value that exists in *source_with_input* into the
+        matching element of *target* (both arguments have the same 2-level layout).
+
+        The input key is added inside the semiotic class mapping (e.g., inside 
+        "cardinal", "time", etc.), not at the token level. The original structures are
+        **not** modified; a deep copy of *target* is returned.
+
+        Parameters
+        ----------
+        source_with_input : Any
+            Structure that already contains ``"input"`` values.
+        target : Any
+            Structure that must receive those ``"input"`` values.
+
+        Returns
+        -------
+        Any
+            A fresh structure equal to *target* but with the extra ``"input"``
+            entries.
+        """
+        merged = deepcopy(target)
+
+        # Walk the two-level list in lock-step.
+        for src_row, tgt_row in zip(source, merged):
+            for src_item, tgt_item in zip(src_row, tgt_row):
+                src_tokens: OrderedDict = src_item.get("tokens", OrderedDict())
+                tgt_tokens: OrderedDict = tgt_item.get("tokens", OrderedDict())
+
+                # Only copy if the key is present on the source side.
+                if INPUT_KEY in src_tokens:
+                    input_value = src_tokens[INPUT_KEY]
+                    
+                    # Find the semiotic class in target tokens and add input there
+                    for key, value in tgt_tokens.items():
+                        if isinstance(value, OrderedDict) and key != INPUT_KEY:
+                            # This is a semiotic class (cardinal, time, etc.)
+                            value[INPUT_KEY] = input_value
+                            break
+                    else:
+                        # If no semiotic class found, check if it's a simple name token
+                        if "name" in tgt_tokens:
+                            # For name tokens, append input to the name value with brackets
+                            original_name = tgt_tokens["name"]
+                            tgt_tokens["name"] = f"{original_name} input: {input_value}"
+
+        return merged
+
     def normalize(
         self, text: str, verbose: bool = False, punct_pre_process: bool = False, punct_post_process: bool = False
     ) -> str:
@@ -354,6 +417,17 @@ class Normalizer:
         self.parser(tagged_text)
         tokens = self.parser.parse()
         split_tokens = self._split_tokens_to_reduce_number_of_permutations(tokens)
+
+        if self.project_input:
+            tagged_lattice = self.find_input_tags(text)
+            tagged_text_input = Normalizer.select_tag(tagged_lattice)
+            logger.debug(tagged_text_input)
+
+            self.parser(tagged_text_input)
+            input_tokens = self.parser.parse()
+            split_input_tokens = self._split_tokens_to_reduce_number_of_permutations(input_tokens)
+            split_tokens = self._merge_input_field(split_input_tokens, split_tokens)
+
         output = ""
         for s in split_tokens:
             try:
@@ -361,6 +435,7 @@ class Normalizer:
                 verbalizer_lattice = None
                 for tagged_text in tags_reordered:
                     tagged_text = pynini.escape(tagged_text)
+                    logger.debug(tagged_text)
 
                     verbalizer_lattice = self.find_verbalizer(tagged_text)
                     if verbalizer_lattice.num_states() != 0:
@@ -562,32 +637,55 @@ class Normalizer:
 
     def _permute(self, d: OrderedDict) -> List[str]:
         """
-        Creates reorderings of dictionary elements and serializes as strings
+        Creates reorderings of dictionary elements and serialises them as strings.
 
-        Args:
-            d: (nested) dictionary of key value pairs
-
-        Return permutations of different string serializations of key value pairs
+        - Respects PRESERVE_ORDER_KEY (no shuffling when it is present).
+        - Forces RAW_KEY (if present) to be the *last* element, so the total
+        permutations drop from n! to (n-1)!.
+        - Fixes the earlier “extra }” bug by closing nested blocks with **one**
+        brace, not two.
         """
-        l = []
-        if PRESERVE_ORDER_KEY in d.keys():
-            d_permutations = [d.items()]
+        # ---------- validation --------------------------------------------------
+        if list(d.keys()).count(INPUT_KEY) > 1:
+            raise ValueError(f"`{INPUT_KEY}` must occur at most once in each dict")
+
+        # ---------- choose permutation source -----------------------------------
+        if PRESERVE_ORDER_KEY in d:
+            if INPUT_KEY in d and next(reversed(d)) != INPUT_KEY:
+                raise ValueError(
+                    f"When {PRESERVE_ORDER_KEY} is set, `{INPUT_KEY}` must already be last")
+            d_permutations = [tuple(d.items())]          # preserve order
         else:
-            d_permutations = itertools.permutations(d.items())
+            items = list(d.items())
+            if INPUT_KEY in d:
+                raw_item    = (INPUT_KEY, d[INPUT_KEY])
+                other_items = [kv for kv in items if kv[0] != INPUT_KEY]
+                d_permutations = [perm + (raw_item,)
+                                for perm in itertools.permutations(other_items)]
+            else:
+                d_permutations = itertools.permutations(items)
+
+        # ---------- render every selected permutation ---------------------------
+        serialisations: List[str] = []
         for perm in d_permutations:
             subl = [""]
             for k, v in perm:
                 if isinstance(v, str):
-                    subl = ["".join(x) for x in itertools.product(subl, [f"{k}: \"{v}\" "])]
+                    subl = ["".join(x) for x in itertools.product(
+                                subl, [f'{k}: "{v}" '])]
                 elif isinstance(v, OrderedDict):
                     rec = self._permute(v)
-                    subl = ["".join(x) for x in itertools.product(subl, [f" {k} {{ "], rec, [f" }} "])]
+                    # NOTE: single closing brace fixes the extra-`}` problem
+                    subl = ["".join(x) for x in itertools.product(
+                                subl, [f" {k} {{ "], rec, [" } "])]
                 elif isinstance(v, bool):
-                    subl = ["".join(x) for x in itertools.product(subl, [f"{k}: true "])]
+                    subl = ["".join(x) for x in itertools.product(
+                                subl, [f"{k}: true "])]
                 else:
-                    raise ValueError("Key: " + str(k) + " Value: " + str(v))
-            l.extend(subl)
-        return l
+                    raise ValueError(f"Key: {k!r}  Value: {v!r}")
+            serialisations.extend(subl)
+
+        return serialisations
 
     def generate_permutations(self, tokens: List[dict]):
         """
@@ -629,6 +727,18 @@ class Normalizer:
         Returns: tagged lattice
         """
         lattice = text @ self.tagger.fst
+        return lattice
+
+    def find_input_tags(self, text: str) -> 'pynini.FstLike':
+        """
+        Given text use tagger Fst to tag text
+
+        Args:
+            text: sentence
+
+        Returns: tagged lattice
+        """
+        lattice = text @ self.tagger_input_projector.fst
         return lattice
 
     @staticmethod
@@ -748,6 +858,11 @@ def parse_args():
         help="Add this flag to add spaces around square brackets, otherwise text between square brackets won't be normalized",
         action="store_true",
     )
+    parser.add_argument(
+        "--project_input",
+        help="Add this flag to project input text to TN output. This is useful for getting a mapping between input and output text.",
+        action="store_true",
+    )
     parser.add_argument("--overwrite_cache", help="Add this flag to re-create .far grammar files", action="store_true")
     parser.add_argument(
         "--whitelist",
@@ -785,6 +900,7 @@ if __name__ == "__main__":
         post_process=not args.no_post_process,
         cache_dir=args.cache_dir,
         overwrite_cache=args.overwrite_cache,
+        project_input=args.project_input,
         whitelist=whitelist,
         lang=args.language,
         max_number_of_permutations_per_split=args.max_number_of_permutations_per_split,
@@ -829,6 +945,8 @@ if __name__ == "__main__":
                 write_file(args.output_file, normalizer_prediction)
                 logger.info(f"- Normalized. Writing out to {args.output_file}")
             else:
+                if isinstance(normalizer_prediction, list):
+                    normalizer_prediction = "\n".join(normalizer_prediction)
                 logger.info(normalizer_prediction)
 
     logger.info(f"Execution time: {perf_counter() - start_time:.02f} sec")

--- a/nemo_text_processing/text_normalization/normalize.py
+++ b/nemo_text_processing/text_normalization/normalize.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 from glob import glob
 from math import factorial
 from time import perf_counter
-from typing import Dict, List, Optional, Union, Any
+from typing import Any, Dict, List, Optional, Union
 
 import pynini
 import regex
@@ -200,7 +200,10 @@ class Normalizer:
             )
 
         self.verbalizer = VerbalizeFinalFst(
-            deterministic=deterministic, cache_dir=cache_dir, overwrite_cache=overwrite_cache, project_input=project_input
+            deterministic=deterministic,
+            cache_dir=cache_dir,
+            overwrite_cache=overwrite_cache,
+            project_input=project_input,
         )
         self.max_number_of_permutations_per_split = max_number_of_permutations_per_split
         self.parser = TokenParser()
@@ -337,7 +340,7 @@ class Normalizer:
         Copy the ``"input"`` value that exists in *source_with_input* into the
         matching element of *target* (both arguments have the same 2-level layout).
 
-        The input key is added inside the semiotic class mapping (e.g., inside 
+        The input key is added inside the semiotic class mapping (e.g., inside
         "cardinal", "time", etc.), not at the token level. The original structures are
         **not** modified; a deep copy of *target* is returned.
 
@@ -365,7 +368,7 @@ class Normalizer:
                 # Only copy if the key is present on the source side.
                 if INPUT_KEY in src_tokens:
                     input_value = src_tokens[INPUT_KEY]
-                    
+
                     # Find the semiotic class in target tokens and add input there
                     for key, value in tgt_tokens.items():
                         if isinstance(value, OrderedDict) and key != INPUT_KEY:
@@ -652,16 +655,14 @@ class Normalizer:
         # ---------- choose permutation source -----------------------------------
         if PRESERVE_ORDER_KEY in d:
             if INPUT_KEY in d and next(reversed(d)) != INPUT_KEY:
-                raise ValueError(
-                    f"When {PRESERVE_ORDER_KEY} is set, `{INPUT_KEY}` must already be last")
-            d_permutations = [tuple(d.items())]          # preserve order
+                raise ValueError(f"When {PRESERVE_ORDER_KEY} is set, `{INPUT_KEY}` must already be last")
+            d_permutations = [tuple(d.items())]  # preserve order
         else:
             items = list(d.items())
             if INPUT_KEY in d:
-                raw_item    = (INPUT_KEY, d[INPUT_KEY])
+                raw_item = (INPUT_KEY, d[INPUT_KEY])
                 other_items = [kv for kv in items if kv[0] != INPUT_KEY]
-                d_permutations = [perm + (raw_item,)
-                                for perm in itertools.permutations(other_items)]
+                d_permutations = [perm + (raw_item,) for perm in itertools.permutations(other_items)]
             else:
                 d_permutations = itertools.permutations(items)
 
@@ -671,16 +672,13 @@ class Normalizer:
             subl = [""]
             for k, v in perm:
                 if isinstance(v, str):
-                    subl = ["".join(x) for x in itertools.product(
-                                subl, [f'{k}: "{v}" '])]
+                    subl = ["".join(x) for x in itertools.product(subl, [f'{k}: "{v}" '])]
                 elif isinstance(v, OrderedDict):
                     rec = self._permute(v)
                     # NOTE: single closing brace fixes the extra-`}` problem
-                    subl = ["".join(x) for x in itertools.product(
-                                subl, [f" {k} {{ "], rec, [" } "])]
+                    subl = ["".join(x) for x in itertools.product(subl, [f" {k} {{ "], rec, [" } "])]
                 elif isinstance(v, bool):
-                    subl = ["".join(x) for x in itertools.product(
-                                subl, [f"{k}: true "])]
+                    subl = ["".join(x) for x in itertools.product(subl, [f"{k}: true "])]
                 else:
                     raise ValueError(f"Key: {k!r}  Value: {v!r}")
             serialisations.extend(subl)

--- a/nemo_text_processing/text_normalization/token_parser.py
+++ b/nemo_text_processing/text_normalization/token_parser.py
@@ -16,6 +16,7 @@ import string
 from collections import OrderedDict
 from typing import Dict, List, Union
 
+INPUT_KEY = "input"
 PRESERVE_ORDER_KEY = "preserve_order"
 EOS = "<EOS>"
 

--- a/tests/nemo_text_processing/en/test_address.py
+++ b/tests/nemo_text_processing/en/test_address.py
@@ -18,13 +18,16 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestAddress:
-    normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
-    )
+    normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
 
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)

--- a/tests/nemo_text_processing/en/test_address.py
+++ b/tests/nemo_text_processing/en/test_address.py
@@ -18,12 +18,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestAddress:
     normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, post_process=True
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
     )
 
     normalizer_with_audio_en = (
@@ -47,3 +47,14 @@ class TestAddress:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_address.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_cardinal.py
+++ b/tests/nemo_text_processing/en/test_cardinal.py
@@ -62,7 +62,7 @@ class TestCardinal:
     @pytest.mark.unit
     def test_norm(self, test_input, expected):
         pred = self.normalizer_en.normalize(test_input, verbose=False, punct_post_process=False)
-        assert pred == expected, f"input: {test_input}"
+        assert pred == expected
 
         if self.normalizer_with_audio_en:
             pred_non_deterministic = self.normalizer_with_audio_en.normalize(

--- a/tests/nemo_text_processing/en/test_cardinal.py
+++ b/tests/nemo_text_processing/en/test_cardinal.py
@@ -19,7 +19,7 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output, assert_projecting_output
 
 
 class TestCardinal:
@@ -41,12 +41,12 @@ class TestCardinal:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_cardinal_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
     normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, post_process=True
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
     )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
@@ -68,3 +68,25 @@ class TestCardinal:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic, f"input: {test_input}"
+
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', project_input=True, input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_cardinal.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_cardinal.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False, punct_post_process=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_cardinal.py
+++ b/tests/nemo_text_processing/en/test_cardinal.py
@@ -19,7 +19,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestCardinal:
@@ -45,9 +50,7 @@ class TestCardinal:
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
-    normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
-    )
+    normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS

--- a/tests/nemo_text_processing/en/test_date.py
+++ b/tests/nemo_text_processing/en/test_date.py
@@ -19,7 +19,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestDate:
@@ -45,9 +50,7 @@ class TestDate:
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
-    normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
-    )
+    normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS

--- a/tests/nemo_text_processing/en/test_date.py
+++ b/tests/nemo_text_processing/en/test_date.py
@@ -19,7 +19,7 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestDate:
@@ -41,12 +41,12 @@ class TestDate:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_date_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
     normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, post_process=True
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
     )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
@@ -82,3 +82,25 @@ class TestDate:
                 test_input, punct_post_process=False, n_tagged=30
             )
             assert expected in pred_non_deterministic
+
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', project_input=True, input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_date.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_date.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_decimal.py
+++ b/tests/nemo_text_processing/en/test_decimal.py
@@ -19,7 +19,7 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestDecimal:
@@ -41,11 +41,11 @@ class TestDecimal:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_decimal_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
-    normalizer_en = Normalizer(input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False, post_process=True)
+    normalizer_en = Normalizer(input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False)
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS
@@ -66,3 +66,25 @@ class TestDecimal:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', project_input=True, input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_decimal.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_decimal.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_decimal.py
+++ b/tests/nemo_text_processing/en/test_decimal.py
@@ -19,7 +19,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestDecimal:

--- a/tests/nemo_text_processing/en/test_electronic.py
+++ b/tests/nemo_text_processing/en/test_electronic.py
@@ -19,7 +19,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestElectronic:

--- a/tests/nemo_text_processing/en/test_electronic.py
+++ b/tests/nemo_text_processing/en/test_electronic.py
@@ -19,13 +19,16 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestElectronic:
     inverse_normalizer_en = InverseNormalizer(lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     inverse_normalizer_en_cased = InverseNormalizer(
         lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, input_case="cased"
+    )
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )
 
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_electronic.txt'))
@@ -40,11 +43,21 @@ class TestElectronic:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_electronic_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_electronic.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
     normalizer_en = Normalizer(input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
+    )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS
@@ -65,3 +78,10 @@ class TestElectronic:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_electronic.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_fraction.py
+++ b/tests/nemo_text_processing/en/test_fraction.py
@@ -19,11 +19,14 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestFraction:
     normalizer_en = Normalizer(input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
+    )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS
@@ -44,3 +47,10 @@ class TestFraction:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_fraction.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_fraction.py
+++ b/tests/nemo_text_processing/en/test_fraction.py
@@ -19,7 +19,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestFraction:

--- a/tests/nemo_text_processing/en/test_math.py
+++ b/tests/nemo_text_processing/en/test_math.py
@@ -18,7 +18,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestMath:
@@ -45,7 +50,9 @@ class TestMath:
             )
             assert expected in pred_non_deterministic
 
-    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_math.txt'))
     @pytest.mark.run_only_on('CPU')

--- a/tests/nemo_text_processing/en/test_math.py
+++ b/tests/nemo_text_processing/en/test_math.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestMath:
@@ -44,3 +44,12 @@ class TestMath:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_math.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_measure.py
+++ b/tests/nemo_text_processing/en/test_measure.py
@@ -20,13 +20,16 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestMeasure:
     inverse_normalizer_en = InverseNormalizer(lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     inverse_normalizer_en_cased = InverseNormalizer(
         lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, input_case="cased"
+    )
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )
 
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_measure.txt'))
@@ -41,11 +44,21 @@ class TestMeasure:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_measure_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_measure.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
     normalizer_en = Normalizer(input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
+    )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS
@@ -66,3 +79,10 @@ class TestMeasure:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_measure.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_measure.py
+++ b/tests/nemo_text_processing/en/test_measure.py
@@ -20,7 +20,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestMeasure:

--- a/tests/nemo_text_processing/en/test_money.py
+++ b/tests/nemo_text_processing/en/test_money.py
@@ -40,16 +40,16 @@ class TestMoney:
     @pytest.mark.unit
     def test_denorm(self, test_input, expected):
         pred = self.inverse_normalizer_en.inverse_normalize(test_input, verbose=False)
-        assert pred == expected, f"input: {test_input}"
+        assert pred == expected
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
-        assert pred == expected, f"input: {test_input}"
+        assert pred == expected
 
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_money_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
-        assert pred == expected, f"input: {test_input}"
+        assert pred == expected
 
     normalizer_en = Normalizer(
         input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, post_process=False
@@ -65,7 +65,7 @@ class TestMoney:
     @pytest.mark.unit
     def test_norm(self, test_input, expected):
         pred = self.normalizer_en.normalize(test_input, verbose=False)
-        assert pred == expected, f"input: {test_input}"
+        assert pred == expected
 
         if self.normalizer_with_audio_en:
             pred_non_deterministic = self.normalizer_with_audio_en.normalize(

--- a/tests/nemo_text_processing/en/test_money.py
+++ b/tests/nemo_text_processing/en/test_money.py
@@ -87,7 +87,11 @@ class TestMoney:
         assert_projecting_output(pred, expected, test_input)
 
     normalizer_en_projecting = Normalizer(
-        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False,
+        input_case='cased',
+        lang='en',
+        project_input=True,
+        cache_dir=CACHE_DIR,
+        overwrite_cache=False,
     )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_money.txt'))

--- a/tests/nemo_text_processing/en/test_normalization_with_audio.py
+++ b/tests/nemo_text_processing/en/test_normalization_with_audio.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, get_test_cases_multiple
+from tests.nemo_text_processing.utils import CACHE_DIR, get_test_cases_multiple
 
 
 class TestNormalizeWithAudio:

--- a/tests/nemo_text_processing/en/test_ordinal.py
+++ b/tests/nemo_text_processing/en/test_ordinal.py
@@ -20,7 +20,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestOrdinal:

--- a/tests/nemo_text_processing/en/test_ordinal.py
+++ b/tests/nemo_text_processing/en/test_ordinal.py
@@ -20,13 +20,16 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestOrdinal:
     inverse_normalizer_en = InverseNormalizer(lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     inverse_normalizer_en_cased = InverseNormalizer(
         lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, input_case="cased"
+    )
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )
 
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_ordinal.txt'))
@@ -41,11 +44,21 @@ class TestOrdinal:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_ordinal_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_ordinal.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
     normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
+    )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS
@@ -66,3 +79,10 @@ class TestOrdinal:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_ordinal.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_punctuation.py
+++ b/tests/nemo_text_processing/en/test_punctuation.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 
 from nemo_text_processing.text_normalization.normalize import Normalizer
 
-from tests.nemo_text_processing.utils import CACHE_DIR, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import CACHE_DIR, assert_projecting_output, parse_test_case_file
 
 
 class TestPunctuation:
@@ -45,7 +45,11 @@ class TestPunctuation:
         assert pred == expected, f"for input |{test_input}|: pred: |{pred}| != expected: |{expected}|"
 
     normalizer_en_projecting = Normalizer(
-        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False,
+        input_case='cased',
+        lang='en',
+        project_input=True,
+        cache_dir=CACHE_DIR,
+        overwrite_cache=False,
     )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_punctuation.txt'))

--- a/tests/nemo_text_processing/en/test_punctuation.py
+++ b/tests/nemo_text_processing/en/test_punctuation.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 
 from nemo_text_processing.text_normalization.normalize import Normalizer
 
-from ..utils import CACHE_DIR, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, parse_test_case_file, assert_projecting_output
 
 
 class TestPunctuation:
@@ -43,3 +43,21 @@ class TestPunctuation:
     def test_norm_python_punct_post_process(self, test_input, expected):
         pred = self.normalizer_en.normalize(test_input, verbose=True, punct_post_process=True)
         assert pred == expected, f"for input |{test_input}|: pred: |{pred}| != expected: |{expected}|"
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False,
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_punctuation.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False, punct_post_process=False)
+        assert_projecting_output(pred, expected, test_input)
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_punctuation_match_input.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project_python_punct_post_process(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False, punct_post_process=True)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_range.py
+++ b/tests/nemo_text_processing/en/test_range.py
@@ -18,7 +18,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestRange:
@@ -45,7 +50,9 @@ class TestRange:
             )
             assert expected in pred_non_deterministic
 
-    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_range.txt'))
     @pytest.mark.run_only_on('CPU')

--- a/tests/nemo_text_processing/en/test_range.py
+++ b/tests/nemo_text_processing/en/test_range.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestRange:
@@ -44,3 +44,12 @@ class TestRange:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_range.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_roman.py
+++ b/tests/nemo_text_processing/en/test_roman.py
@@ -18,7 +18,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestRoman:
@@ -46,7 +51,9 @@ class TestRoman:
             )
             assert expected in pred_non_deterministic
 
-    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_roman.txt'))
     @pytest.mark.run_only_on('CPU')
@@ -57,7 +64,9 @@ class TestRoman:
 
         if self.normalizer_with_audio_en:
             pred_non_deterministic = self.normalizer_with_audio_en.normalize(
-                test_input, n_tagged=30, punct_post_process=False,
+                test_input,
+                n_tagged=30,
+                punct_post_process=False,
             )
             if test_input == expected:
                 assert expected in pred_non_deterministic

--- a/tests/nemo_text_processing/en/test_roman.py
+++ b/tests/nemo_text_processing/en/test_roman.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestRoman:
@@ -35,8 +35,8 @@ class TestRoman:
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_norm(self, test_input, expected):
-        # pred = self.normalizer_en.normalize(test_input, verbose=False)
-        # assert pred == expected
+        pred = self.normalizer_en.normalize(test_input, verbose=False)
+        assert pred == expected
 
         if self.normalizer_with_audio_en:
             pred_non_deterministic = self.normalizer_with_audio_en.normalize(
@@ -45,3 +45,21 @@ class TestRoman:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic
+
+    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_roman.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
+        if self.normalizer_with_audio_en:
+            pred_non_deterministic = self.normalizer_with_audio_en.normalize(
+                test_input, n_tagged=30, punct_post_process=False,
+            )
+            if test_input == expected:
+                assert expected in pred_non_deterministic
+            else:
+                assert f'{expected}[{test_input}]' in pred_non_deterministic

--- a/tests/nemo_text_processing/en/test_serial.py
+++ b/tests/nemo_text_processing/en/test_serial.py
@@ -39,7 +39,7 @@ class TestSerial:
     @pytest.mark.unit
     def test_norm(self, test_input, expected):
         pred = self.normalizer_en.normalize(test_input, verbose=False, punct_post_process=False)
-        assert pred == expected, f"input: {test_input}"
+        assert pred == expected
 
         if self.normalizer_with_audio_en:
             pred_non_deterministic = self.normalizer_with_audio_en.normalize(

--- a/tests/nemo_text_processing/en/test_serial.py
+++ b/tests/nemo_text_processing/en/test_serial.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestSerial:
@@ -43,3 +43,12 @@ class TestSerial:
                 punct_post_process=False,
             )
             assert expected in pred_non_deterministic, f"input: {test_input}"
+
+    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_serial.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False, punct_post_process=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_serial.py
+++ b/tests/nemo_text_processing/en/test_serial.py
@@ -18,7 +18,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestSerial:
@@ -44,7 +49,9 @@ class TestSerial:
             )
             assert expected in pred_non_deterministic, f"input: {test_input}"
 
-    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_serial.txt'))
     @pytest.mark.run_only_on('CPU')

--- a/tests/nemo_text_processing/en/test_special_text.py
+++ b/tests/nemo_text_processing/en/test_special_text.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestSpecialText:
@@ -46,3 +46,12 @@ class TestSpecialText:
                 punct_post_process=True,
             )
             assert expected in pred_non_deterministic, f"input: {test_input}"
+
+    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_special_text.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_special_text.py
+++ b/tests/nemo_text_processing/en/test_special_text.py
@@ -18,7 +18,12 @@ from parameterized import parameterized
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestSpecialText:
@@ -47,7 +52,9 @@ class TestSpecialText:
             )
             assert expected in pred_non_deterministic, f"input: {test_input}"
 
-    normalizer_en_projecting = Normalizer(input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
 
     @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_special_text.txt'))
     @pytest.mark.run_only_on('CPU')

--- a/tests/nemo_text_processing/en/test_telephone.py
+++ b/tests/nemo_text_processing/en/test_telephone.py
@@ -20,7 +20,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestTelephone:

--- a/tests/nemo_text_processing/en/test_telephone.py
+++ b/tests/nemo_text_processing/en/test_telephone.py
@@ -20,13 +20,16 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestTelephone:
     inverse_normalizer_en = InverseNormalizer(lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     inverse_normalizer_en_cased = InverseNormalizer(
         lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, input_case="cased"
+    )
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )
 
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_telephone.txt'))
@@ -41,11 +44,21 @@ class TestTelephone:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_telephone_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_telephone.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
     normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
+    )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
         if RUN_AUDIO_BASED_TESTS
@@ -64,3 +77,10 @@ class TestTelephone:
                 test_input, n_tagged=10, punct_post_process=False
             )
             assert expected in pred_non_deterministic
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_telephone.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_text_split.py
+++ b/tests/nemo_text_processing/en/test_text_split.py
@@ -16,12 +16,12 @@ import pytest
 
 from nemo_text_processing.text_normalization.normalize import Normalizer
 
-from ..utils import CACHE_DIR
+from tests.nemo_text_processing.utils import CACHE_DIR
 
 
 class TestTextSentenceSplit:
     normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, post_process=True
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
     )
 
     @pytest.mark.run_only_on('CPU')
@@ -36,6 +36,27 @@ class TestTextSentenceSplit:
             '123rd, St. Patrick. This is a.b. and there is c.b.',
         ]
         sentences = self.normalizer_en.split_text_into_sentences(text)
+
+        for s, gt in zip(sentences, gt_sentences):
+            print(s, gt)
+        assert gt_sentences == sentences
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_text_sentence_split_project(self):
+        text = "This happened in 1918 when Mrs. and Mr. Smith paid $111.12 in U.S.A. at 9 a.m. on Dec. 1. 2020. And Jan. 17th. This is an example. He paid $123 for this desk. 123rd, St. Patrick. This is a. b. and there is c.b."
+        gt_sentences = [
+            'This happened in 1918 when Mrs. and Mr. Smith paid $111.12 in U.S.A. at 9 a.m. on Dec. 1. 2020.',
+            'And Jan. 17th.',
+            'This is an example.',
+            'He paid $123 for this desk.',
+            '123rd, St. Patrick. This is a.b. and there is c.b.',
+        ]
+        sentences = self.normalizer_en_projecting.split_text_into_sentences(text)
 
         for s, gt in zip(sentences, gt_sentences):
             print(s, gt)

--- a/tests/nemo_text_processing/en/test_text_split.py
+++ b/tests/nemo_text_processing/en/test_text_split.py
@@ -20,9 +20,7 @@ from tests.nemo_text_processing.utils import CACHE_DIR
 
 
 class TestTextSentenceSplit:
-    normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
-    )
+    normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit

--- a/tests/nemo_text_processing/en/test_time.py
+++ b/tests/nemo_text_processing/en/test_time.py
@@ -19,7 +19,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestTime:

--- a/tests/nemo_text_processing/en/test_time.py
+++ b/tests/nemo_text_processing/en/test_time.py
@@ -19,7 +19,7 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestTime:
@@ -40,7 +40,7 @@ class TestTime:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_time_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
@@ -63,3 +63,25 @@ class TestTime:
                 test_input, n_tagged=10, punct_post_process=False
             )
             assert expected in pred_non_deterministic
+
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', project_input=True, input_case="cased", cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_time.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', project_input=True, cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_time.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_whitelist.py
+++ b/tests/nemo_text_processing/en/test_whitelist.py
@@ -20,7 +20,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestWhitelist:

--- a/tests/nemo_text_processing/en/test_word.py
+++ b/tests/nemo_text_processing/en/test_word.py
@@ -20,13 +20,16 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from ..utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file
+from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
 
 
 class TestWord:
     inverse_normalizer_en = InverseNormalizer(lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     inverse_normalizer_en_cased = InverseNormalizer(
         lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, input_case="cased"
+    )
+    inverse_normalizer_en_projecting = InverseNormalizer(
+        lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )
 
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_word.txt'))
@@ -41,12 +44,22 @@ class TestWord:
     @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_word_cased.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_denorm(self, test_input, expected):
+    def test_denorm_cased(self, test_input, expected):
         pred = self.inverse_normalizer_en_cased.inverse_normalize(test_input, verbose=False)
         assert pred == expected
 
+    @parameterized.expand(parse_test_case_file('en/data_inverse_text_normalization/test_cases_word.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_denorm_project(self, test_input, expected):
+        pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)
+
     normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, post_process=True
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
+    )
+    normalizer_en_projecting = Normalizer(
+        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )
     normalizer_with_audio_en = (
         NormalizerWithAudio(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
@@ -66,3 +79,10 @@ class TestWord:
                 test_input, n_tagged=30, punct_post_process=False
             )
             assert expected in pred_non_deterministic, f"input: {test_input}"
+
+    @parameterized.expand(parse_test_case_file('en/data_text_normalization/test_cases_word.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm_project(self, test_input, expected):
+        pred = self.normalizer_en_projecting.normalize(test_input, verbose=False)
+        assert_projecting_output(pred, expected, test_input)

--- a/tests/nemo_text_processing/en/test_word.py
+++ b/tests/nemo_text_processing/en/test_word.py
@@ -20,7 +20,12 @@ from nemo_text_processing.inverse_text_normalization.inverse_normalize import In
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from nemo_text_processing.text_normalization.normalize_with_audio import NormalizerWithAudio
 
-from tests.nemo_text_processing.utils import CACHE_DIR, RUN_AUDIO_BASED_TESTS, parse_test_case_file, assert_projecting_output
+from tests.nemo_text_processing.utils import (
+    CACHE_DIR,
+    RUN_AUDIO_BASED_TESTS,
+    assert_projecting_output,
+    parse_test_case_file,
+)
 
 
 class TestWord:
@@ -55,9 +60,7 @@ class TestWord:
         pred = self.inverse_normalizer_en_projecting.inverse_normalize(test_input, verbose=False)
         assert_projecting_output(pred, expected, test_input)
 
-    normalizer_en = Normalizer(
-        input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False
-    )
+    normalizer_en = Normalizer(input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False)
     normalizer_en_projecting = Normalizer(
         input_case='cased', lang='en', cache_dir=CACHE_DIR, overwrite_cache=False, project_input=True
     )

--- a/tests/nemo_text_processing/utils.py
+++ b/tests/nemo_text_processing/utils.py
@@ -88,15 +88,15 @@ def normalize_whitespace(text: str) -> str:
 def extract_projected_content(text: str) -> List[Tuple[str, str, str]]:
     """
     Extract all projected content from a string with paired brackets format.
-    
+
     Args:
         text: Text containing paired projections like "text [normalized][original] more text"
-    
+
     Returns:
         List of (prefix_text, normalized, original) tuples where prefix_text is the text before this projection
-    
+
     Examples:
-        "i can use your [card ending in eight eight seven six][card ending in 8876]" 
+        "i can use your [card ending in eight eight seven six][card ending in 8876]"
             -> [("i can use your ", "card ending in eight eight seven six", "card ending in 8876")]
     """
     import re
@@ -126,10 +126,10 @@ def extract_projected_content(text: str) -> List[Tuple[str, str, str]]:
 def reconstruct_sentences(text: str) -> Tuple[str, str]:
     """
     Reconstruct the normalized output and original input from projected text.
-    
+
     Args:
         text: Text with paired projections like "text [normalized][original] more text"
-        
+
     Returns:
         Tuple of (normalized_sentence, original_sentence)
     """
@@ -157,32 +157,34 @@ def reconstruct_sentences(text: str) -> Tuple[str, str]:
 
     return normalize_whitespace(normalized_sentence), normalize_whitespace(original_sentence)
 
+
 def remove_spaces_around_punctuation(text):
     """Remove spaces that are adjacent to punctuation characters."""
     punctuation_chars = r'[,!?.;:(){}[\]<>/@#$%^&*+=|\\`~"\'-]'
-    
+
     # Remove spaces before punctuation
     text = re.sub(r'\s+(?=' + punctuation_chars + ')', '', text)
-    
+
     # Remove spaces after punctuation
     text = re.sub(r'(?<=' + punctuation_chars + r')\s+', '', text)
-    
+
     return text
+
 
 def assert_projecting_output(predicted: str, expected_output: str, original_input: str) -> None:
     """
     Enhanced assertion for projecting tests with paired bracket format.
-    
+
     Args:
         predicted: The actual output from the normalizer (with [normalized][original] pairs)
         expected_output: The expected normalized output
         original_input: The original input that should be reconstructed
-        
+
     Raises:
         AssertionError: If the projecting output doesn't match expectations
     """
     import re
-    
+
     predicted = normalize_whitespace(predicted)
     expected_output = normalize_whitespace(expected_output)
     original_input = normalize_whitespace(original_input)
@@ -210,7 +212,7 @@ def assert_projecting_output(predicted: str, expected_output: str, original_inpu
     # Check if original input contains punctuation
     # Define punctuation characters that trigger space-agnostic comparison
     punctuation_chars = r'[,!?.;:(){}[\]<>/@#$%^&*+=|\\`~"\'-]'
-    
+
     if re.search(punctuation_chars, original_input):
         # Remove all spaces for comparison when punctuation is present
         original_input_no_spaces = re.sub(r'\s+', '', original_input)

--- a/tests/nemo_text_processing/utils.py
+++ b/tests/nemo_text_processing/utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+import re
+from typing import List, Tuple
 
 CACHE_DIR = None
 RUN_AUDIO_BASED_TESTS = False
@@ -76,3 +78,159 @@ def get_test_cases_multiple(file_name: str = 'data_text_normalization/en/test_ca
                 normalized_options.append(line.strip())
     test_pairs.append((written, normalized_options))
     return test_pairs
+
+
+def normalize_whitespace(text: str) -> str:
+    """Normalize whitespace for comparison."""
+    return re.sub(r'\s+', ' ', text.strip())
+
+
+def extract_projected_content(text: str) -> List[Tuple[str, str, str]]:
+    """
+    Extract all projected content from a string with paired brackets format.
+    
+    Args:
+        text: Text containing paired projections like "text [normalized][original] more text"
+    
+    Returns:
+        List of (prefix_text, normalized, original) tuples where prefix_text is the text before this projection
+    
+    Examples:
+        "i can use your [card ending in eight eight seven six][card ending in 8876]" 
+            -> [("i can use your ", "card ending in eight eight seven six", "card ending in 8876")]
+    """
+    import re
+
+    # Pattern to match paired brackets with NO space between them
+    pattern = r'\[([^\]]+)\]\[([^\]]+)\]'
+
+    result = []
+    last_end = 0
+
+    for match in re.finditer(pattern, text):
+        # Get the text before this projection pair (don't strip - preserve spacing)
+        prefix = text[last_end : match.start()]
+        normalized = match.group(1)
+        original = match.group(2)
+        result.append((prefix, normalized, original))
+        last_end = match.end()
+
+    # If there's text after the last projection, we need to handle it
+    remaining = text[last_end:]
+    if remaining:
+        result.append((remaining, "", ""))
+
+    return result
+
+
+def reconstruct_sentences(text: str) -> Tuple[str, str]:
+    """
+    Reconstruct the normalized output and original input from projected text.
+    
+    Args:
+        text: Text with paired projections like "text [normalized][original] more text"
+        
+    Returns:
+        Tuple of (normalized_sentence, original_sentence)
+    """
+    projections = extract_projected_content(text)
+
+    if not projections:
+        # No projections found, return the text as-is for both
+        return text, text
+
+    normalized_parts = []
+    original_parts = []
+
+    for prefix, normalized, original in projections:
+        if normalized and original:
+            # This prefix has a projection following it
+            normalized_parts.append(prefix + normalized)
+            original_parts.append(prefix + original)
+        else:
+            # This is trailing text with no projection
+            normalized_parts.append(prefix)
+            original_parts.append(prefix)
+
+    normalized_sentence = "".join(normalized_parts)
+    original_sentence = "".join(original_parts)
+
+    return normalize_whitespace(normalized_sentence), normalize_whitespace(original_sentence)
+
+def remove_spaces_around_punctuation(text):
+    """Remove spaces that are adjacent to punctuation characters."""
+    punctuation_chars = r'[,!?.;:(){}[\]<>/@#$%^&*+=|\\`~"\'-]'
+    
+    # Remove spaces before punctuation
+    text = re.sub(r'\s+(?=' + punctuation_chars + ')', '', text)
+    
+    # Remove spaces after punctuation
+    text = re.sub(r'(?<=' + punctuation_chars + r')\s+', '', text)
+    
+    return text
+
+def assert_projecting_output(predicted: str, expected_output: str, original_input: str) -> None:
+    """
+    Enhanced assertion for projecting tests with paired bracket format.
+    
+    Args:
+        predicted: The actual output from the normalizer (with [normalized][original] pairs)
+        expected_output: The expected normalized output
+        original_input: The original input that should be reconstructed
+        
+    Raises:
+        AssertionError: If the projecting output doesn't match expectations
+    """
+    import re
+    
+    predicted = normalize_whitespace(predicted)
+    expected_output = normalize_whitespace(expected_output)
+    original_input = normalize_whitespace(original_input)
+
+    # Case 1: No normalization occurred, no projection needed
+    if expected_output == original_input:
+        assert predicted == expected_output, (
+            f"No normalization expected but got different output.\n"
+            f"Expected: '{expected_output}'\n"
+            f"Got:      '{predicted}'"
+        )
+        return
+
+    # Case 2: Extract and reconstruct both sentences
+    reconstructed_normalized, reconstructed_original = reconstruct_sentences(predicted)
+
+    # Verify the normalized version matches expected output
+    assert reconstructed_normalized == expected_output, (
+        f"Reconstructed normalized output doesn't match expected.\n"
+        f"Expected:      '{expected_output}'\n"
+        f"Reconstructed: '{reconstructed_normalized}'\n"
+        f"Full output:   '{predicted}'"
+    )
+
+    # Check if original input contains punctuation
+    # Define punctuation characters that trigger space-agnostic comparison
+    punctuation_chars = r'[,!?.;:(){}[\]<>/@#$%^&*+=|\\`~"\'-]'
+    
+    if re.search(punctuation_chars, original_input):
+        # Remove all spaces for comparison when punctuation is present
+        original_input_no_spaces = re.sub(r'\s+', '', original_input)
+        original_input_no_spaces = re.sub(r'``', '"', original_input_no_spaces)
+        original_input_no_spaces = re.sub(r'-', 'to', original_input_no_spaces)
+        reconstructed_original_no_spaces = re.sub(r'\s+', '', reconstructed_original)
+        reconstructed_original_no_spaces = re.sub(r'``', '"', reconstructed_original_no_spaces)
+        reconstructed_original_no_spaces = re.sub(r'-', 'to', reconstructed_original_no_spaces)
+
+        assert reconstructed_original_no_spaces == original_input_no_spaces, (
+            f"Reconstructed original input doesn't match actual input (ignoring spaces).\n"
+            f"Expected:      '{original_input}' -> '{original_input_no_spaces}'\n"
+            f"Reconstructed: '{reconstructed_original}' -> '{reconstructed_original_no_spaces}'\n"
+            f"Full output:   '{predicted}'"
+        )
+    else:
+        # No punctuation, use exact comparison
+        assert reconstructed_original == original_input, (
+            f"Reconstructed original input doesn't match actual input.\n"
+            f"Expected:      '{original_input}'\n"
+            f"Reconstructed: '{reconstructed_original}'\n"
+            f"Full output:   '{predicted}'"
+        )


### PR DESCRIPTION
# What does this PR do ?

This PR aims to add a feature which enables projection of the input to the output string.

E.g., when project_input is enabled, running ITN on the string `the road is one kilometer long` produces the output `the road is [1 km][one kilometer] long`. Here the content in the left square bracket is the inverse normalized output, and the content in the right bracket which lead to the output.

This is useful in e.g. speech pipelines where ITN is used for processing the output of an ASR model, and correct word level timestamps are required of the processed output. While it is possible to align the input with the output using the fst_alignment script in the repo, this is not as robust as directly computing the input, together with the output, using the fst.

Currently, only English has been pushed, but I have it mostly working in all languages. Decided to keep the PR small initially, to make it easier to review. A full PR with support for all languages will touch most of the files in the repo.

All tests aren't currently passing, but I am working on it. The primary purpose of this PR is to gauge if this has interest for the larger community, or if I should just maintain a fork with project_input support.

The method currently relies on a custom input tag, which isn't supported by sparrowhawk. I would like to add sparrowhawk support, but currently am not sure how.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Have you signed your commits? Use ``git commit -s`` to sign.
- [ ] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [ ] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [ ] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [ ] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [ ] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [ ] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [ ] Remove import guards (`try import: ... except: ...`) if not already done.
- [ ] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [ ] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
