### PR TITLE
docs: add Rust implementation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ We welcome community contributions! Please refer to the [CONTRIBUTING.md](CONTRI
 
 
 
+Alternative Implementations
+---------------------------
+
+| Project | Language | Description |
+|---------|----------|-------------|
+| [text-processing-rs](https://github.com/FluidInference/text-processing-rs) | Rust | ITN and TN for 7 languages (EN, DE, ES, FR, HI, JA, ZH) with C FFI for Swift/Python integration. 100% compatible with NeMo test suite. |
+
+
 Citation
 --------
 


### PR DESCRIPTION
## Summary

Adds an "Alternative Implementations" section to the README linking to [text-processing-rs](https://github.com/FluidInference/text-processing-rs), a Rust port of NeMo Text Processing.

- Supports ITN and TN for 7 languages (EN, DE, ES, FR, HI, JA, ZH)
- 100% compatible with NeMo test suite (3,011 tests passing)
- Includes C FFI for Swift/Python integration
- Licensed under Apache 2.0